### PR TITLE
Fix two instances of undefined behavior

### DIFF
--- a/codegen/rust/src/lib.rs
+++ b/codegen/rust/src/lib.rs
@@ -633,13 +633,13 @@ fn generate_header(_ast: &AST, h: &Header, ctx: &mut Context) {
         member_values.push(quote! {
             #name: unsafe {
                 #ty::new(&mut*std::ptr::slice_from_raw_parts_mut(
-                    buf.as_mut_ptr().add(#offset), #required_bytes))?
+                    buf.add(#offset), #required_bytes))?
             }
         });
         set_statements.push(quote! {
             self.#name = unsafe {
                 #ty::new(&mut*std::ptr::slice_from_raw_parts_mut(
-                    buf.as_mut_ptr().add(#offset), #required_bytes))?
+                    buf.add(#offset), #required_bytes))?
             }
         });
         offset += required_bytes;
@@ -648,11 +648,13 @@ fn generate_header(_ast: &AST, h: &Header, ctx: &mut Context) {
     generated.extend(quote! {
         impl<'a> Header<'a> for #name<'a> {
             fn new(buf: &'a mut [u8]) -> Result<Self, TryFromSliceError> {
+                let buf = buf.as_mut_ptr();
                 Ok(Self {
                     #(#member_values),*
                 })
             }
             fn set(&mut self, buf: &'a mut [u8]) -> Result<(), TryFromSliceError> {
+                let buf = buf.as_mut_ptr();
                 #(#set_statements);*;
                 Ok(())
             }


### PR DESCRIPTION
This PR contains two fixes for undefined behavior. The first one is easy to see/explain (053c6ff): the second arg to `slice_from_raw_parts_mut()` should be the length of the slice, but previously it was the end of the subslice in reference to the original buffer.

The second one (f60a374) is more nuanced, so I'll explain how I got to it. I was poking around the repo and tried running one of the examples under [Miri](https://github.com/rust-lang/miri):

```
% cargo miri run --bin p4-macro-test
... snip ...
error: Undefined Behavior: trying to reborrow <2472> for SharedReadOnly permission at alloc1312[0x0], but that tag does not exist in the borrow stack for this location
    --> /home/john/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/mod.rs:2142:1
     |
2142 | fmt_refs! { Debug, Display, Octal, Binary, LowerHex, UpperHex, LowerExp, UpperExp }
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     | |
     | trying to reborrow <2472> for SharedReadOnly permission at alloc1312[0x0], but that tag does not exist in the borrow stack for this location
     | this error occurs as part of a reborrow at alloc1312[0x0..0x6]
     |
     = help: this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental
     = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

     = note: inside `<&mut [u8] as std::fmt::Debug>::fmt` at /home/john/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/mod.rs:2136:71
     = note: inside `<&&mut [u8] as std::fmt::Debug>::fmt` at /home/john/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/mod.rs:2132:62
     = note: inside closure at /home/john/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/builders.rs:332:17
     = note: inside `std::result::Result::<(), std::fmt::Error>::and_then::<(), [closure@std::fmt::DebugTuple::field::{closure#0}]>` at /home/john/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs:1332:22
     = note: inside `std::fmt::DebugTuple::field` at /home/john/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/builders.rs:319:23
note: inside `<p4rs::bit_slice<48_usize> as std::fmt::Debug>::fmt` at /home/john/github/p4/lang/p4rs/src/bits.rs:12:10
    --> /home/john/github/p4/lang/p4rs/src/bits.rs:12:10
     |
12   | #[derive(Debug)]
     |          ^^^^^
     = note: inside `core::fmt::run` at /home/john/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/mod.rs:1242:5
     = note: inside `std::fmt::write` at /home/john/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/mod.rs:1210:26
     = note: inside `<std::io::StdoutLock as std::io::Write>::write_fmt` at /home/john/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/io/mod.rs:1655:15
     = note: inside `<&std::io::Stdout as std::io::Write>::write_fmt` at /home/john/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/io/stdio.rs:712:9
     = note: inside `<std::io::Stdout as std::io::Write>::write_fmt` at /home/john/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/io/stdio.rs:686:9
     = note: inside `std::io::stdio::print_to::<std::io::Stdout>` at /home/john/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/io/stdio.rs:1015:21
     = note: inside `std::io::_print` at /home/john/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/io/stdio.rs:1028:5
note: inside `main` at /home/john/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/macros.rs:103:9
    --> lang/p4-macro-test/src/main.rs:12:5
     |
12   |     println!("dst: {:x?}", eth.dst_addr);
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: this error originates in the macro `fmt_refs` (in Nightly builds, run with -Z macro-backtrace for more info)

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

error: aborting due to previous error
```

This seems strange - it's complaining about the (derived) `Debug` implementation on `eth.dst_addr`, which is a [`bit_slice`](https://github.com/oxidecomputer/p4/blob/e876f2a24680d955ceb36f78531f4ad5e8b36aef/lang/p4rs/src/bits.rs#L12-L13): its `Debug` impl should be just printing the slice. If Miri doesn't approve, I assumed that meant there was something wrong with the way `dst_addr` was created.

The generated code for `ethernet_t::new()` is:

```rust
fn new(buf: &'a mut [u8]) -> Result<Self, TryFromSliceError> {
    Ok(Self {
        dst_addr: unsafe {
            bit_slice::<'a, 48>::new(
                &mut *std::ptr::slice_from_raw_parts_mut(
                    buf.as_mut_ptr().add(0),
                    6,
                ),
            )?
        },
        src_addr: unsafe {
            bit_slice::<'a, 48>::new(
                &mut *std::ptr::slice_from_raw_parts_mut(
                    buf.as_mut_ptr().add(6),
                    6,
                ),
            )?
        },
        ether_type: unsafe {
            bit_slice::< 'a, 16>::new(
                &mut *std::ptr::slice_from_raw_parts_mut(
                    buf.as_mut_ptr().add(12),
                    2,
                ),
            )?
        },
    })
}
```

This code temporarily creates multiple mutable references that alias the same memory:

1. We're given `buf`, a `&mut [u8]` of length at least 14.
2. We create a `bit_slice` for `dst_addr` which wraps a `&mut [u8]` of length 6 (the first 6 bytes in `buf`). At this point both `buf` and the bit slice going into `dst_addr` are mutable references to the same memory. I don't know whether this is already illegal or if we don't hit undefined behavior until the next step.
3. To create `src_addr`, we call `buf.as_mut_ptr()`, which _accesses_ the memory now-alaised by `dst_addr` through `buf`, which is definitely undefined behavior.

To fix this, this PR changes the generated code to:

```rust
fn new(buf: &'a mut [u8]) -> Result<Self, TryFromSliceError> {
    let buf = buf.as_mut_ptr();
    Ok(Self {
        dst_addr: unsafe {
            bit_slice::<'a, 48>::new(
                &mut *std::ptr::slice_from_raw_parts_mut(
                    buf.add(0),
                    6,
                ),
            )?
        },
        src_addr: unsafe {
            bit_slice::<'a, 48>::new(
                &mut *std::ptr::slice_from_raw_parts_mut(
                    buf.add(6),
                    6,
                ),
            )?
        },
        ether_type: unsafe {
            bit_slice::< 'a, 16>::new(
                &mut *std::ptr::slice_from_raw_parts_mut(
                    buf.add(12),
                    2,
                ),
            )?
        },
    })
}
```

This converts `buf` from a slice to a raw pointer on entry, and we no longer call methods on an aliased `&mut [u8]` in order to create the `bit_slices` (we operate only on the raw pointer). With this change, we're able to run the example under Miri with no errors.

As a side note, I mentioned above that `buf` needs to have length >= 14; `new()` should either assert that that's true or be marked unsafe, since it uses `unsafe` code that assumes that length.