### PR TITLE
use qualified table names everywhere

### DIFF
--- a/codegen/rust/src/lib.rs
+++ b/codegen/rust/src/lib.rs
@@ -8,8 +8,9 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use p4::ast::{
-    ControlParameter, DeclarationInfo, Direction, Expression, ExpressionKind,
-    Lvalue, NameInfo, Parser, Type, UserDefinedType, AST,
+    Control, ControlParameter, DeclarationInfo, Direction, Expression,
+    ExpressionKind, Lvalue, NameInfo, Parser, Table, Type, UserDefinedType,
+    AST,
 };
 use p4::hlir::Hlir;
 use p4::util::resolve_lvalue;
@@ -330,4 +331,34 @@ fn is_rust_reference(lval: &Lvalue, names: &HashMap<String, NameInfo>) -> bool {
     } else {
         false
     }
+}
+
+fn qualified_table_name(
+    chain: &Vec<(String, &Control)>,
+    table: &Table,
+) -> String {
+    table_qname(chain, table, '.')
+}
+
+fn qualified_table_function_name(
+    chain: &Vec<(String, &Control)>,
+    table: &Table,
+) -> String {
+    table_qname(chain, table, '_')
+}
+
+fn table_qname(
+    chain: &Vec<(String, &Control)>,
+    table: &Table,
+    sep: char,
+) -> String {
+    let mut qname = String::new();
+    for c in chain {
+        if c.0.is_empty() {
+            continue;
+        }
+        qname += &format!("{}{}", c.0, sep);
+    }
+    qname += &table.name;
+    qname
 }

--- a/codegen/rust/src/p4struct.rs
+++ b/codegen/rust/src/p4struct.rs
@@ -126,6 +126,20 @@ impl<'a> StructGenerator<'a> {
                     }
                 }
             })
+        } else {
+            structure.extend(quote! {
+                impl #name {
+                    pub fn valid_header_size(&self) -> usize { 0 }
+
+                    pub fn to_bitvec(&self) -> BitVec<u8, Msb0> {
+                        bitvec![u8, Msb0; 0; 0]
+                    }
+
+                    pub fn dump(&self) -> String {
+                        std::string::String::new()
+                    }
+                }
+            })
         }
 
         self.ctx.structs.insert(s.name.clone(), structure);

--- a/p4/src/ast.rs
+++ b/p4/src/ast.rs
@@ -350,26 +350,32 @@ impl Control {
     /// control block variables and including their tables. In the returned
     /// vector, the table in the second element of the tuple belongs to the
     /// control in the first element.
-    pub fn tables<'a>(&'a self, ast: &'a AST) -> Vec<(Vec<&Control>, &Table)> {
-        self.tables_rec(ast, Vec::new())
+    pub fn tables<'a>(
+        &'a self,
+        ast: &'a AST,
+    ) -> Vec<(Vec<(String, &Control)>, &Table)> {
+        self.tables_rec(ast, String::new(), Vec::new())
     }
 
     fn tables_rec<'a>(
         &'a self,
         ast: &'a AST,
-        mut chain: Vec<&'a Control>,
-    ) -> Vec<(Vec<&Control>, &Table)> {
+        name: String,
+        mut chain: Vec<(String, &'a Control)>,
+    ) -> Vec<(Vec<(String, &Control)>, &Table)> {
         let mut result = Vec::new();
-        chain.push(self);
+        chain.push((name, self));
         for table in &self.tables {
             result.push((chain.clone(), table));
         }
         for v in &self.variables {
-            if let Type::UserDefined(name) = &v.ty {
-                if let Some(control_inst) = ast.get_control(name) {
-                    result.extend_from_slice(
-                        &control_inst.tables_rec(ast, chain.clone()),
-                    );
+            if let Type::UserDefined(typename) = &v.ty {
+                if let Some(control_inst) = ast.get_control(typename) {
+                    result.extend_from_slice(&control_inst.tables_rec(
+                        ast,
+                        v.name.clone(),
+                        chain.clone(),
+                    ));
                 }
             }
         }

--- a/test/src/controller_multiple_instantiation.rs
+++ b/test/src/controller_multiple_instantiation.rs
@@ -1,0 +1,10 @@
+p4_macro::use_p4!(
+    p4 = "test/src/p4/controller_multiple_instantiation.p4",
+    pipeline_name = "cmi",
+);
+
+#[test]
+fn controller_multiple_instantiation() -> Result<(), anyhow::Error> {
+    println!("it compiles!");
+    Ok(())
+}

--- a/test/src/disag_router.rs
+++ b/test/src/disag_router.rs
@@ -156,10 +156,12 @@ fn disag_router() -> Result<(), anyhow::Error> {
     let p = b"i know the muffin man";
     let mut sc = [0u8; 23];
     sc[0] = 1;
-    sc[1] = 3;
-    sc[2] = 2;
-    sc[3] = 0x86;
-    sc[4] = 0xdd;
+    sc[1] = 0;
+    sc[2] = 3;
+    sc[3] = 0;
+    sc[4] = 2;
+    sc[5] = 0x86;
+    sc[6] = 0xdd;
     write(
         &phy0,
         101,

--- a/test/src/dynamic_router.rs
+++ b/test/src/dynamic_router.rs
@@ -84,7 +84,7 @@ fn dynamic_router() -> Result<(), anyhow::Error> {
             },
             0,
             "control plane rule 1".into(),
-            &mut pipeline.router_table_router,
+            &mut pipeline.router_router,
         );
 
         add_router_table_entry_forward(
@@ -99,7 +99,7 @@ fn dynamic_router() -> Result<(), anyhow::Error> {
             },
             0,
             "control plane rule 2".into(),
-            &mut pipeline.router_table_router,
+            &mut pipeline.router_router,
         );
 
         add_router_table_entry_forward(
@@ -114,7 +114,7 @@ fn dynamic_router() -> Result<(), anyhow::Error> {
             },
             0,
             "control plane rule 3".into(),
-            &mut pipeline.router_table_router,
+            &mut pipeline.router_router,
         );
 
         softnpu::run_pipeline(rx, tx, &mut pipeline);

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -11,6 +11,8 @@
 #[cfg(test)]
 mod basic_router;
 #[cfg(test)]
+mod controller_multiple_instantiation;
+#[cfg(test)]
 mod disag_router;
 #[cfg(test)]
 mod dynamic_router;

--- a/test/src/mac_rewrite.rs
+++ b/test/src/mac_rewrite.rs
@@ -78,17 +78,17 @@ fn mac_rewrite() -> Result<(), anyhow::Error> {
         let addr_d: Ipv6Addr = "fe80::aae1:deff:fe01:701d".parse().unwrap();
         let addr_e: Ipv6Addr = "fe80::aae1:deff:fe01:701e".parse().unwrap();
 
-        pipeline.add_local_table_entry(
+        pipeline.add_local_local_entry(
             "local".into(),
             addr_c.octets().as_ref(),
             &Vec::new(),
         );
-        pipeline.add_local_table_entry(
+        pipeline.add_local_local_entry(
             "local".into(),
             addr_d.octets().as_ref(),
             &Vec::new(),
         );
-        pipeline.add_local_table_entry(
+        pipeline.add_local_local_entry(
             "local".into(),
             addr_e.octets().as_ref(),
             &Vec::new(),
@@ -96,19 +96,19 @@ fn mac_rewrite() -> Result<(), anyhow::Error> {
 
         // resolver table entries
 
-        pipeline.add_resolver_table_entry(
+        pipeline.add_router_resolver_resolver_entry(
             "rewrite_dst".into(),
             addr_c.octets().as_ref(),
             &[0x44, 0x44, 0x44, 0x44, 0x44, 0x44],
         );
 
-        pipeline.add_resolver_table_entry(
+        pipeline.add_router_resolver_resolver_entry(
             "rewrite_dst".into(),
             addr_d.octets().as_ref(),
             &[0x33, 0x33, 0x33, 0x33, 0x33, 0x33],
         );
 
-        pipeline.add_resolver_table_entry(
+        pipeline.add_router_resolver_resolver_entry(
             "rewrite_dst".into(),
             addr_e.octets().as_ref(),
             &[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
@@ -133,7 +133,7 @@ fn mac_rewrite() -> Result<(), anyhow::Error> {
             },
             0,
             "control plane rule 1".into(),
-            &mut pipeline.router_table_router,
+            &mut pipeline.router_router,
         );
 
         add_router_table_entry_forward(
@@ -153,7 +153,7 @@ fn mac_rewrite() -> Result<(), anyhow::Error> {
             },
             0,
             "control plane rule 2".into(),
-            &mut pipeline.router_table_router,
+            &mut pipeline.router_router,
         );
 
         add_router_table_entry_forward(
@@ -173,7 +173,7 @@ fn mac_rewrite() -> Result<(), anyhow::Error> {
             },
             0,
             "control plane rule 3".into(),
-            &mut pipeline.router_table_router,
+            &mut pipeline.router_router,
         );
 
         softnpu::run_pipeline(rx, tx, &mut pipeline);

--- a/test/src/p4/controller_multiple_instantiation.p4
+++ b/test/src/p4/controller_multiple_instantiation.p4
@@ -1,0 +1,63 @@
+#include <test/src/p4/core.p4>
+#include <test/src/p4/softnpu.p4>
+
+SoftNPU(
+    parse(),
+    ingress()
+) main;
+
+struct headers_t { }
+
+parser parse(
+    packet_in pkt,
+    out headers_t headers,
+    inout IngressMetadata ingress,
+){
+    state start { transition accept; }
+}
+
+control resolver(
+    in bit<32> x,
+    out bool resolved,
+) {
+    action resolve() {
+        resolved = true;
+    }
+    table arp {
+        key = { x: exact; }
+        actions = { resolve; }
+        default_action = NoAction;
+    }
+    apply { arp.apply(); }
+}
+
+control foo() {
+    resolver() resolver;
+    apply {
+        bool resolved;
+        resolver.apply(32w47, resolved);
+    }
+}
+
+control bar() {
+    resolver() resolver;
+    resolver() taco;
+    apply {
+        bool resolved;
+        resolver.apply(32w1701, resolved);
+    }
+}
+
+control ingress(
+    inout headers_t hdr,
+    inout IngressMetadata ingress,
+    inout EgressMetadata egress,
+) {
+    foo() taco;
+    bar() pizza;
+
+    apply {
+        taco.apply();
+        pizza.apply();
+    }
+}


### PR DESCRIPTION
Fixes #8

## The Fix

This fixes the problems described in #8 by making sure we are using qualified table names everywhere in generated rust code.

Any time a table is referenced, it is qualified relative to the control it is being referenced in. For example if a table `muffin` lives in the control `baz`, which is instantiated in control `bar` which is instantiated in control `foo`. Then

- The fully qualified name is `foo.bar.baz.muffin`.
- The qualified name from foo is `bar.baz.muffin`.
- The qualified name from `bar` is `baz.muffin`.
- The qualified name from `baz` is `muffin.

This disambiguates tables that have the same name, or control blocks that are instantiated multiple times.

The dot-delimited names above are used for the string-based table identifiers in the `Pipeline` trait. For Rust code generation purposes, underscore-delimited names are used.

## Follow Ups

This fix is primarily necessary because the compiler currently constructs pipeline objects such that all tables are constructed up front and passed into control blocks as parameters. This makes it straightforward to implement a control API that modifies all tables. However, it does lose some of the hierarchical structuring intrinsic to P4 programs. It's possible that generated Rust could benefit from a more hierarchical organization.

Doing table name qualification was rather awkward and feels very bolted on. Most of the complexity was shouldered by the code generation stage, which does not seem right. Seems like we're missing intermediate data structures similar to the HLIR data structures that would make code generation a more straightforward process instead of taking on the role of calculating qualified names by traversing controller chains all over the place.