### PR TITLE
implement confused-endian semantics

### DIFF
--- a/codegen/rust/src/control.rs
+++ b/codegen/rust/src/control.rs
@@ -399,7 +399,7 @@ impl<'a> ControlGenerator<'a> {
                                 let size = n as usize;
                                 action_fn_args.push(quote! {{
                                     let mut x = bitvec![mut u8, Msb0; 0; #size];
-                                    x.store_be(#v);
+                                    x.store_le(#v);
                                     x
                                 }});
                             }

--- a/codegen/rust/src/expression.rs
+++ b/codegen/rust/src/expression.rs
@@ -113,7 +113,7 @@ impl<'a> ExpressionGenerator<'a> {
         quote! {
             {
                 let mut x = bitvec![mut u8, Msb0; 0; #width];
-                x.store_be(#value);
+                x.store_le(#value);
                 x
             }
         }

--- a/codegen/rust/src/header.rs
+++ b/codegen/rust/src/header.rs
@@ -65,10 +65,24 @@ impl<'a> HeaderGenerator<'a> {
             });
             let end = offset + size;
             set_statements.push(quote! {
-                self.#name = buf.view_bits::<Msb0>()[#offset..#end].to_owned()
+                self.#name = {
+                    let mut b = buf.view_bits::<Msb0>()[#offset..#end].to_owned();
+                    // NOTE this barfing and then unbarfing a vec is to handle
+                    // the p4 confused-endian data model.
+                    let mut v = b.into_vec();
+                    v.reverse();
+                    let b = BitVec::<u8, Msb0>::from_vec(v);
+                    b
+                }
             });
             to_bitvec_statements.push(quote! {
-                x[#offset..#end] |= &self.#name
+                // NOTE this barfing and then unbarfing a vec is to handle
+                // the p4 confused-endian data model.
+                let mut v = self.#name.clone().into_vec();
+                v.reverse();
+                let b = BitVec::<u8, Msb0>::from_vec(v);
+                x[#offset..#end] |= &b;
+
             });
             checksum_statements.push(quote! {
                 csum = p4rs::bitmath::add(csum.clone(), self.#name.csum())
@@ -116,6 +130,11 @@ impl<'a> HeaderGenerator<'a> {
                 fn to_bitvec(&self) -> BitVec<u8, Msb0> {
                     let mut x = bitvec![u8, Msb0; 0u8; Self::size()];
                     #(#to_bitvec_statements);*;
+                    // NOTE handling P4s confused endian byte ordering
+                    //let mut v = x.into_vec();
+                    //v.reverse();
+                    //let x = BitVec::<u8, Msb0>::from_vec(v);
+                    //x.reverse();
                     x
                 }
             }

--- a/codegen/rust/src/pipeline.rs
+++ b/codegen/rust/src/pipeline.rs
@@ -174,7 +174,7 @@ impl<'a> PipelineGenerator<'a> {
                 let mut ingress_metadata = IngressMetadata{
                     port: {
                         let mut x = bitvec![mut u8, Msb0; 0; 16];
-                        x.store_be(port);
+                        x.store_le(port);
                         x
                     },
                     ..Default::default()
@@ -227,7 +227,7 @@ impl<'a> PipelineGenerator<'a> {
                     //println!("{}", "---".dimmed());
                     return None;
                 } else {
-                    egress_metadata.port.load_be()
+                    egress_metadata.port.load_le()
                     //egress_metadata.port.as_raw_slice()[0]
                 };
 

--- a/dtrace/accepted.d
+++ b/dtrace/accepted.d
@@ -1,0 +1,3 @@
+control_accepted* {
+    printf("\n%s\n", copyinstr(arg0));
+}

--- a/dtrace/dropped.d
+++ b/dtrace/dropped.d
@@ -1,0 +1,3 @@
+control_dropped* {
+    printf("\n%s\n", copyinstr(arg0));
+}

--- a/dtrace/dtrace-list-probes.sh
+++ b/dtrace/dtrace-list-probes.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pfexec dtrace -l -n softnpu_provider*:::

--- a/dtrace/softnpu-monitor.d
+++ b/dtrace/softnpu-monitor.d
@@ -1,0 +1,31 @@
+::parser_transition{
+    printf("%s", copyinstr(arg0));
+}
+
+::parser_dropped {
+    printf("parser dropped\n");
+}
+
+::parser_accepted {
+    printf("%s", copyinstr(arg0));
+}
+
+::control_apply{
+    printf("%s", copyinstr(arg0));
+}
+
+::control_dropped {
+    printf("control dropped\n");
+}
+
+::control_accepted {
+    printf("control accepted\n");
+}
+
+::control_table_hit {
+    printf("%s", copyinstr(arg0));
+}
+
+::control_table_miss {
+    printf("%s", copyinstr(arg0));
+}

--- a/dtrace/softnpu-stats.d
+++ b/dtrace/softnpu-stats.d
@@ -1,0 +1,37 @@
+::parser_transition{
+    @stats["parser transition", copyinstr(arg0)] = count();
+}
+
+::parser_dropped {
+    @stats["parser", "drop"] = count();
+}
+
+::parser_accepted {
+    @stats["parser", "accept"] = count();
+}
+
+::control_apply{
+    @stats["control apply", copyinstr(arg0)]= count();
+}
+
+::control_dropped {
+    @stats["control", "drop"] = count();
+}
+
+::control_accepted {
+    @stats["control", "accept"] = count();
+}
+
+::control_table_hit {
+    @stats["table hit", copyinstr(arg0)] = count();
+}
+
+::control_table_miss {
+    @stats["table miss", copyinstr(arg0)] = count();
+}
+
+tick-10sec
+{
+    printa(@stats);
+    printf("==========================================================================================================================\n");
+}

--- a/p4/examples/codegen/hub.p4
+++ b/p4/examples/codegen/hub.p4
@@ -39,7 +39,7 @@ control ingress(
 
     action drop() { }
 
-    action forward(bit<8> port) {
+    action forward(bit<16> port) {
         egress.port = port;
     }
 
@@ -53,8 +53,8 @@ control ingress(
         }
         default_action = drop;
         const entries = {
-            8w0 : forward(1);
-            8w1 : forward(0);
+            16w0 : forward(16w1);
+            16w1 : forward(16w0);
         }
     }
 

--- a/p4/examples/codegen/softnpu.p4
+++ b/p4/examples/codegen/softnpu.p4
@@ -1,11 +1,11 @@
 struct IngressMetadata {
-    bit<8> port;
+    bit<16> port;
     bool nat;
     bit<16> nat_id;
 }
 
 struct EgressMetadata {
-    bit<8> port;
+    bit<16> port;
     bit<128> nexthop;
     bool drop;
 }

--- a/test/src/p4/router.p4
+++ b/test/src/p4/router.p4
@@ -83,9 +83,7 @@ control local(
 
         bit<16> ll = 16w0xff02;
 
-        //TODO this is backwards should be
-        //if(hdr.ipv6.dst[127:112] == ll) {
-        if(hdr.ipv6.dst[15:0] == ll) {
+        if(hdr.ipv6.dst[127:112] == ll) {
             is_local = true;
         }
     }
@@ -161,7 +159,8 @@ control ingress(
 
             // Decap the sidecar header.
             hdr.sidecar.setInvalid();
-            hdr.ethernet.ether_type = 16w0x86dd;
+            //hdr.ethernet.ether_type = 16w0x86dd;
+            hdr.ethernet.ether_type = 16w0xdd86;
 
             // No more processing is required for sidecar packets, they simple
             // go out the sidecar port corresponding to the source scrimlet
@@ -181,7 +180,8 @@ control ingress(
 
         if (local_dst) {
             hdr.sidecar.setValid();
-            hdr.ethernet.ether_type = 16w0x0901;
+            //hdr.ethernet.ether_type = 16w0x0901;
+            hdr.ethernet.ether_type = 16w0x0109;
 
             //SC_FORWARD_TO_USERSPACE
             hdr.sidecar.sc_code = 8w0x01;

--- a/test/src/p4/sidecar-lite.p4
+++ b/test/src/p4/sidecar-lite.p4
@@ -394,9 +394,7 @@ control local(
         if(hdr.ipv6.isValid()) {
             local_v6.apply();
             bit<16> ll = 16w0xff02;
-            //TODO this is backwards should be?
-            //if(hdr.ipv6.dst[127:112] == ll) {
-            if(hdr.ipv6.dst[15:0] == ll) {
+            if(hdr.ipv6.dst[127:112] == ll) {
                 is_local = true;
             }
         }

--- a/test/src/softnpu.rs
+++ b/test/src/softnpu.rs
@@ -122,7 +122,9 @@ pub fn run_pipeline<
 
                         egress_count[port] += 1;
                     }
-                    None => {}
+                    None => {
+                        println!("drop");
+                    }
                 }
             }
             ig.consume(frames_in).unwrap();


### PR DESCRIPTION
The p4 spec states that the first bit from a packet extracts into the last bit of bit-string types, this means that we go from protocol-endian to p4-endian and then back to protocol-endian on the way out.

This patch introduces reordering logic over `bit<n>` types to ensure that bits land in header fields in the expected order.

Fixes #5.