### PR TITLE
VLAN switch

### DIFF
--- a/book/code/build.rs
+++ b/book/code/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    let src = [
+        "src/bin/hello-world.p4",
+        "src/bin/vlan-switch.p4",
+        "src/bin/headers.p4",
+        "src/bin/softnpu.p4",
+        "src/bin/core.p4",
+    ];
+    for x in src {
+        println!("cargo:rerun-if-changed={}", x);
+    }
+}

--- a/book/code/src/bin/headers.p4
+++ b/book/code/src/bin/headers.p4
@@ -1,0 +1,112 @@
+header sidecar_h {
+    bit<8> sc_code;
+    bit<16> sc_ingress;
+    bit<16> sc_egress;
+    bit<16> sc_ether_type;
+    bit<128> sc_payload;
+}
+
+header ethernet_h {
+    bit<48> dst;
+    bit<48> src;
+    bit<16> ether_type;
+}
+
+header vlan_h {
+    bit<3> pcp;
+    bit<1> dei;
+    bit<12> vid;
+    bit<16> ether_type;
+}
+
+header ipv6_h {
+    bit<4>      version;
+    bit<8>      traffic_class;
+    bit<20>     flow_label;
+    bit<16>     payload_len;
+    bit<8>      next_hdr;
+    bit<8>      hop_limit;
+    bit<128>    src;
+    bit<128>    dst;
+}
+
+header ipv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     total_len;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     frag_offset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdr_checksum;
+    bit<32>     src;
+    bit<32>     dst;
+}
+
+header udp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<16> len;
+    bit<16> checksum;
+}
+
+header tcp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<32> seq_no;
+    bit<32> ack_no;
+    bit<4> data_offset;
+    bit<4> res;
+    bit<8> flags;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgent_ptr;
+}
+
+header icmp_h {
+    bit<8> type;
+    bit<8> code;
+    bit<16> hdr_checksum;
+    bit<32> data;
+}
+
+header geneve_h {
+    bit<2> version;
+    bit<6> opt_len;
+    bit<1> ctrl;
+    bit<1> crit;
+    bit<6> reserved;
+    bit<16> protocol;
+    bit<24> vni;
+    bit<8> reserved2;
+}
+
+header arp_h {
+	bit<16>		hw_type;
+	bit<16>		proto_type;
+	bit<8>		hw_addr_len;
+	bit<8>		proto_addr_len;
+	bit<16>		opcode;
+
+	// In theory, the remaining fields should be <varbit>
+	// based on the the two x_len fields.
+	bit<48> sender_mac;
+	bit<32> sender_ip;
+	bit<48> target_mac;
+	bit<32> target_ip;
+}
+
+header ddm_h {
+    bit<8> next_header;
+    bit<8> header_length;
+    bit<8> version;
+    bit<1> ack;
+    bit<7> reserved;
+}
+
+header ddm_element_t {
+    bit<8> id;
+    bit<24> timestamp;
+}

--- a/book/code/src/bin/softnpu.p4
+++ b/book/code/src/bin/softnpu.p4
@@ -1,0 +1,16 @@
+struct ingress_metadata_t {
+    bit<16> port;
+    bool nat;
+    bit<16> nat_id;
+}
+
+struct egress_metadata_t {
+    bit<16> port;
+    bit<128> nexthop_v6;
+    bit<32> nexthop_v4;
+    bool drop;
+}
+
+extern Checksum {
+    bit<16> run<T>(in T data);
+}

--- a/book/code/src/bin/vlan-switch.p4
+++ b/book/code/src/bin/vlan-switch.p4
@@ -1,0 +1,102 @@
+#include <headers.p4>
+#include <softnpu.p4>
+#include <core.p4>
+
+struct headers_t {
+    ethernet_h eth;
+    vlan_h vlan;
+}
+
+parser parse (
+    packet_in pkt,
+    out headers_t h,
+    inout ingress_metadata_t ingress,
+) {
+    state start {
+        pkt.extract(h.eth);
+        if (h.eth.ether_type == 16w0x8100) { transition vlan; } 
+        transition accept;
+    }
+    state vlan {
+        pkt.extract(h.vlan);
+        transition accept;
+    }
+}
+
+control vlan(
+    in bit<16> port,
+    in bit<12> vid,
+    out bool match,
+) {
+    action no_vid_for_port() {
+        match = true;
+    }
+
+    action filter(bit<12> port_vid) { 
+        if (port_vid == vid) { match = true; } 
+    }
+    
+    table port_vlan {
+        key             = { port: exact; }
+        actions         = { no_vid_for_port; filter; }
+        default_action  = no_vid_for_port;
+    }
+
+    apply { port_vlan.apply(); }
+}
+
+control forward(
+    inout headers_t hdr,
+    inout egress_metadata_t egress,
+) {
+    action drop() {}
+    action forward(bit<16> port) { egress.port = port; }
+
+    table fib {
+        key             = { hdr.eth.dst: exact; }
+        actions         = { drop; forward; }
+        default_action  = drop;
+    }
+
+    apply { fib.apply(); }
+}
+    
+
+control ingress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
+    vlan() vlan;
+    forward() fwd;
+    
+    apply {
+        bit<12> vid = 12w0;
+        if (hdr.vlan.isValid()) {
+            vid = hdr.vlan.vid;
+        }
+
+        // check vlan on ingress
+        bool vlan_ok = false;
+        vlan.apply(ingress.port, vid, vlan_ok);
+        if (vlan_ok == false) {
+            egress.drop = true;
+            return;
+        }
+
+        // apply switch forwarding logic
+        fwd.apply(hdr, egress);
+
+        // check vlan on egress
+        vlan.apply(egress.port, vid, vlan_ok);
+        if (vlan_ok == false) {
+            egress.drop = true;
+            return;
+        }
+    }
+}
+
+SoftNPU(
+    parse(), 
+    ingress()
+) main;

--- a/book/code/src/bin/vlan-switch.rs
+++ b/book/code/src/bin/vlan-switch.rs
@@ -18,24 +18,16 @@ fn main() -> Result<(), anyhow::Error> {
     run_test(pipeline, m2, m3)
 }
 
-fn init_tables(pipeline: &mut main_pipeline, m1: [u8;6], m2: [u8;6]) {
+fn init_tables(pipeline: &mut main_pipeline, m1: [u8; 6], m2: [u8; 6]) {
     // add static forwarding entries
-    pipeline.add_fwd_fib_entry(
-        "forward",
-        &m1,
-        &0u16.to_be_bytes()
-    );
-    pipeline.add_fwd_fib_entry(
-        "forward",
-        &m2,
-        &1u16.to_be_bytes()
-    );
+    pipeline.add_fwd_fib_entry("forward", &m1, &0u16.to_be_bytes());
+    pipeline.add_fwd_fib_entry("forward", &m2, &1u16.to_be_bytes());
 
     // port 0 vlan 47
     pipeline.add_vlan_port_vlan_entry(
         "filter",
-        &0u16.to_be_bytes().to_vec(),
-        &47u16.to_be_bytes().to_vec(),
+        0u16.to_be_bytes().as_ref(),
+        47u16.to_be_bytes().as_ref(),
     );
 
     // sanity check the table
@@ -45,14 +37,16 @@ fn init_tables(pipeline: &mut main_pipeline, m1: [u8;6], m2: [u8;6]) {
     // port 1 vlan 47
     pipeline.add_vlan_port_vlan_entry(
         "filter",
-        &1u16.to_be_bytes().to_vec(),
-        &47u16.to_be_bytes().to_vec(),
+        1u16.to_be_bytes().as_ref(),
+        47u16.to_be_bytes().as_ref(),
     );
 }
 
-fn run_test(pipeline: main_pipeline, m2: [u8;6], m3: [u8;6]) 
--> Result<(), anyhow::Error>
-{
+fn run_test(
+    pipeline: main_pipeline,
+    m2: [u8; 6],
+    m3: [u8; 6],
+) -> Result<(), anyhow::Error> {
     // create and run the softnpu instance
     let mut npu = SoftNpu::new(2, pipeline, false);
     let phy1 = npu.phy(0);

--- a/book/code/src/bin/vlan-switch.rs
+++ b/book/code/src/bin/vlan-switch.rs
@@ -1,0 +1,74 @@
+#![allow(clippy::needless_update)]
+use tests::expect_frames;
+use tests::softnpu::{RxFrame, SoftNpu, TxFrame};
+
+p4_macro::use_p4!(
+    p4 = "book/code/src/bin/vlan-switch.p4",
+    pipeline_name = "vlan_switch"
+);
+
+fn main() -> Result<(), anyhow::Error> {
+    let mut pipeline = main_pipeline::new();
+
+    let m1 = [0x33, 0x33, 0x33, 0x33, 0x33, 0x33];
+    let m2 = [0x44, 0x44, 0x44, 0x44, 0x44, 0x44];
+    let m3 = [0x55, 0x55, 0x55, 0x55, 0x55, 0x55];
+
+    init_tables(&mut pipeline, m1, m2);
+    run_test(pipeline, m2, m3)
+}
+
+fn init_tables(pipeline: &mut main_pipeline, m1: [u8;6], m2: [u8;6]) {
+    // add static forwarding entries
+    pipeline.add_fwd_fib_entry(
+        "forward",
+        &m1,
+        &0u16.to_be_bytes()
+    );
+    pipeline.add_fwd_fib_entry(
+        "forward",
+        &m2,
+        &1u16.to_be_bytes()
+    );
+
+    // port 0 vlan 47
+    pipeline.add_vlan_port_vlan_entry(
+        "filter",
+        &0u16.to_be_bytes().to_vec(),
+        &47u16.to_be_bytes().to_vec(),
+    );
+
+    // sanity check the table
+    let x = pipeline.get_vlan_port_vlan_entries();
+    println!("{:#?}", x);
+
+    // port 1 vlan 47
+    pipeline.add_vlan_port_vlan_entry(
+        "filter",
+        &1u16.to_be_bytes().to_vec(),
+        &47u16.to_be_bytes().to_vec(),
+    );
+}
+
+fn run_test(pipeline: main_pipeline, m2: [u8;6], m3: [u8;6]) 
+-> Result<(), anyhow::Error>
+{
+    // create and run the softnpu instance
+    let mut npu = SoftNpu::new(2, pipeline, false);
+    let phy1 = npu.phy(0);
+    let phy2 = npu.phy(1);
+    npu.run();
+
+    // send a packet we expect to make it through
+    phy1.send(&[TxFrame::newv(m2, 0, b"blueberry", 47)])?;
+    expect_frames!(phy2, &[RxFrame::newv(phy1.mac, 0x8100, b"blueberry", 47)]);
+
+    // send 3 packets, we expect the first 2 to get filtered by vlan rules
+    phy1.send(&[TxFrame::newv(m2, 0, b"poppyseed", 74)])?; // 74 != 47
+    phy1.send(&[TxFrame::new(m2, 0, b"banana")])?; // no tag
+    phy1.send(&[TxFrame::newv(m2, 0, b"muffin", 47)])?;
+    phy1.send(&[TxFrame::newv(m3, 0, b"nut", 47)])?; // no forwarding entry
+    expect_frames!(phy2, &[RxFrame::newv(phy1.mac, 0x8100, b"muffin", 47)]);
+
+    Ok(())
+}

--- a/book/text/book.toml
+++ b/book/text/book.toml
@@ -7,3 +7,6 @@ title = "The x4c Book"
 
 [output.html]
 additional-css = ["./theme/highlight.css"]
+
+[output.html.playground]
+runnable = false

--- a/book/text/src/01-03-compile_and_run.md
+++ b/book/text/src/01-03-compile_and_run.md
@@ -13,7 +13,7 @@ All of the programs in this book are available as buildable programs in the
 [oxidecomputer/p4](https://github.com/oxidecomputer/p4) repository in the
 `book/code` directory.
 
-```rust,noplayground
+```rust
 use tests::softnpu::{RxFrame, SoftNpu, TxFrame};
 use tests::{expect_frames};
 
@@ -39,7 +39,7 @@ fn main() -> Result<(), anyhow::Error> {
 
 The program starts with a few Rust imports.
 
-```rust,noplayground
+```rust
 use tests::softnpu::{RxFrame, SoftNpu, TxFrame};
 use tests::{expect_frames};
 ```
@@ -53,14 +53,14 @@ The next line is using the `x4c` compiler to translate P4 code into Rust code
 and dumping that Rust code into our program. The macro literally expands into
 the Rust code emitted by the compiler for the specified P4 source file.
 
-```rust,noplayground
+```rust
 p4_macro::use_p4!(p4 = "book/code/src/bin/hello-world.p4", pipeline_name = "hello");
 ```
 
 The main artifact this produces is a Rust `struct` called `main_pipeline` which is used
 in the code that comes next.
 
-```rust,noplayground
+```rust
 let pipeline = main_pipeline::new();
 let mut npu = SoftNpu::new(2, pipeline, false);
 let phy1 = npu.phy(0);
@@ -76,14 +76,14 @@ process those packets.
 
 Next we run our program on the SoftNpu ASIC.
 
-```rust,noplayground
+```rust
 npu.run();
 ```
 
 However, this does not actually do anything until we pass some packets through
 it, so lets do that.
 
-```rust,noplayground
+```rust
 phy1.send(&[TxFrame::new(phy2.mac, 0, b"hello")])?;
 ```
 
@@ -95,7 +95,7 @@ used in the outgoing Ethernet frame.
 Based on the logic in our P4 program, we would expect this packet to come out
 the second port. Let's test that.
 
-```rust,noplayground
+```rust
 expect_frames!(phy2, &[RxFrame::new(phy1.mac, 0, b"hello")]);
 ```
 
@@ -110,7 +110,7 @@ To complete the hello world program, we do the same thing in the opposite
 direction. Sending the byte string `"world"` as an Ethernet payload into port 2
 and assert that it comes out port 1.
 
-```rust,noplayground
+```rust
 phy2.send(&[TxFrame::new(phy1.mac, 0, b"world")])?;
 expect_frames!(phy1, &[RxFrame::new(phy2.mac, 0, b"world")]);
 ```
@@ -119,7 +119,7 @@ The `expect_frames` macro will also print payloads and the port they came from.
 
 When we run this program we see the following.
 
-```
+```bash
 $ cargo run --bin hello-world
    Compiling x4c-book v0.1.0 (/home/ry/src/p4/book/code)
     Finished dev [unoptimized + debuginfo] target(s) in 2.05s

--- a/book/text/src/02-01-vlan-switch.md
+++ b/book/text/src/02-01-vlan-switch.md
@@ -1,0 +1,501 @@
+# VLAN Switch
+
+This example presents a simple VLAN switch program. This program allows a single
+VLAN id (`vid`) to be set per port. Any packet arriving at a port with a `vid`
+set must carry that `vid` in its Ethernet header or it will be dropped. We'll
+refer to this as VLAN filtering. If a packet makes it past ingress filtering,
+then the forwarding table of the switch is consulted to see what port to send
+the packet out. We limit ourselves to a very simple switch here with a static
+forwarding table. A MAC learning switch will be presented in a later example.
+This switch also does not do flooding for unknown packets, it simply operates on
+the lookup table it has. If an egress port is identified via a forwarding table
+lookup, then egress VLAN filtering is applied. If the `vid` on the packet is
+present on the egress port then the packet is forwarded out that port.
+
+This example is comprised of two programs. A P4 data-plane program and a Rust
+control-plane program.
+
+## P4 Data-Plane Program
+
+Let's start by taking a look at the headers for the P4 program.
+
+```p4
+header ethernet_h {
+    bit<48> dst;
+    bit<48> src;
+    bit<16> ether_type;
+}
+
+header vlan_h {
+    bit<3> pcp;
+    bit<1> dei;
+    bit<12> vid;
+    bit<16> ether_type;
+}
+
+struct headers_t {
+    ethernet_h eth;
+    vlan_h vlan;
+}
+```
+
+An Ethernet frame is normally just 14 bytes with a 6 byte source and destination
+plus a two byte ethertype. However, when VLAN tags are present the ethertype is
+set to `0x8100` and a VLAN header follows. This header contains a 12-bit `vid`
+as well as an ethertype for the header that follows.
+
+A byte-oriented packet diagram shows how these two Ethernet frame variants line
+up.
+
+```
+                     1
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8
++---------------------------+
+|    src    |    dst    |et |
++---------------------------+
++-----------------------------------+
+|    src    |    dst    |et |pdv|et |
++------------------------------------
+```
+
+The structure is always the same for the first 14 bytes. So we can take
+advantage of that when parsing any type of Ethernet frame. Then we can use the
+ethertype field to determine if we are looking at a regular Ethernet frame or a
+VLAN-tagged Ethernet frame.
+
+```p4
+parser parse (
+    packet_in pkt,
+    out headers_t h,
+    inout ingress_metadata_t ingress,
+) {
+    state start {
+        pkt.extract(h.eth);
+        if (h.eth.ether_type == 16w0x8100) { transition vlan; } 
+        transition accept;
+    }
+    state vlan {
+        pkt.extract(h.vlan);
+        transition accept;
+    }
+}
+```
+
+This parser does exactly what we described above. First parse the first 14 bytes
+of the packet as an Ethernet frame. Then conditionally parse the VLAN portion of
+the Ethernet frame if the ethertype indicates we should do so. In a sense we can
+think of the VLAN portion of the Ethernet frame as being it's own independent
+header. We are keying our decisions based on the ethertype, just as we would for
+layer 3 protocol headers.
+
+Our VLAN switch P4 program is broken up into multiple control blocks. We'll
+start with the top level control block and then dive into the control blocks it
+calls into to implement the switch.
+
+```p4
+control ingress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
+    vlan() vlan;
+    forward() fwd;
+    
+    apply {
+        bit<12> vid = 12w0;
+        if (hdr.vlan.isValid()) {
+            vid = hdr.vlan.vid;
+        }
+
+        // check vlan on ingress
+        bool vlan_ok = false;
+        vlan.apply(ingress.port, vid, vlan_ok);
+        if (vlan_ok == false) {
+            egress.drop = true;
+            return;
+        }
+
+        // apply switch forwarding logic
+        fwd.apply(hdr, egress);
+
+        // check vlan on egress
+        vlan.apply(egress.port, vid, vlan_ok);
+        if (vlan_ok == false) {
+            egress.drop = true;
+            return;
+        }
+    }
+}
+```
+
+The first thing that is happening in this program is the instantiation of a few
+other control blocks.
+
+```p4
+vlan() vlan;
+forward() fwd;
+```
+
+We'll be using these control blocks to implement the VLAN filtering and switch
+forwarding logic. For now let's take a look at the higher level packet
+processing logic of the program in the `apply` block.
+
+The first thing we do is start by assuming there is no `vid` by setting it to
+zero. The if the VLAN header is valid we assign the `vid` from the packet header
+to our local `vid` variable. The `isValid` header method returns `true` if
+`extract` was called on that header. Recall from the parser code above, that
+`extract` is only called on `hdr.vlan` if the ethertype on the Ethernet frame is
+`0x1800`.
+
+```p4
+bit<12> vid = 12w0;
+if (hdr.vlan.isValid()) {
+    vid = hdr.vlan.vid;
+}
+```
+
+Next apply VLAN filtering logic. First an indicator variable `vlan_ok` is
+initialized to false. Then we pass that indicator variable along with the port
+the packet came in on and the `vid` we determined above to the VLAN control
+block.
+
+```p4
+bool vlan_ok = false;
+vlan.apply(ingress.port, vid, vlan_ok);
+if (vlan_ok == false) {
+    egress.drop = true;
+    return;
+}
+```
+
+Let's take a look at the VLAN control block. The first thing to note here is the
+direction of parameters. The `port` and `vid` parameters are `in` parameters,
+meaning that the control block can only read from them. The `match` parameter is
+an `out` parameter meaning the control block can only write to it. Consider this
+in the context of the code above. There we are passing in the `vlan_ok` to the
+control block with the expectation that the control block will modify the value
+of the variable. The `out` direction of this control block parameter is what
+makes that possible.
+
+```p4
+control vlan(
+    in bit<16> port,
+    in bit<12> vid,
+    out bool match,
+) {
+    action no_vid_for_port() {
+        match = true;
+    }
+
+    action filter(bit<12> port_vid) { 
+        if (port_vid == vid) { match = true; } 
+    }
+    
+    table port_vlan {
+        key             = { port: exact; }
+        actions         = { no_vid_for_port; filter; }
+        default_action  = no_vid_for_port;
+    }
+
+    apply { port_vlan.apply(); }
+}
+```
+
+Let's look at this control block starting from the `table` declaration. The
+`port_vlan` table has the `port` id as the single key element. There are two
+possible actions `no_vid_for_port` and `filter`. The `no_vid_for_port` fires
+when there is no match for the `port` id. That action unconditionally sets
+`match` to true. The logic here is that if there is no VLAN configure for a port
+e.g., the port is not in the table, then there is no need to do any VLAN
+filtering and just pass the packet along. 
+
+The `filter` action takes a single parameter `port_vid`. This value is populated
+by the table value entry corresponding to the `port` key. There are no static
+table entries in this P4 program, they are provided by a control plane program
+which we'll get to in a bit. The `filter` logic tests if the `port_vid` that has
+been configured by the control plane matches the `vid` on the packet. If the
+test passes then `match` is set to true meaning the packet can continue
+processing.
+
+Popping back up to the top level control block. If `vlan_ok` was not set to
+`true` in the `vlan` control block, then we drop the packet. Otherwise we
+continue on to further processing - forwarding.
+
+Here we are passing the entire header and egress metadata structures into the
+`fwd` control block which is an instantiation of the `forward` control block
+type.
+
+```p4
+fwd.apply(hdr, egress);
+```
+
+Lets take a look at the `forward` control block.
+
+```p4
+control forward(
+    inout headers_t hdr,
+    inout egress_metadata_t egress,
+) {
+    action drop() {}
+    action forward(bit<16> port) { egress.port = port; }
+
+    table fib {
+        key             = { hdr.eth.dst: exact; }
+        actions         = { drop; forward; }
+        default_action  = drop;
+    }
+
+    apply { fib.apply(); }
+}
+```
+
+This simple control block contains a table that maps Ethernet addresses to
+ports. The single element key contains an Ethernet destination and the matching
+action `forward` contains a single 16-bit port value.  When the Ethernet
+destination matches an entry in the table, the egress metadata destination for
+the packet is set to the port id that has been set for that table entry.
+
+Note that in this control block both parameters have an `inout` direction,
+meaning the control block can both read from and write to these parameters.
+Like the `vlan` control block above, there are no static entries here. Entries
+for the table in this control block are filled in by a control-plane program.
+
+Popping back up the stack to our top level control block, the remaining code we
+have is the following.
+
+```p4
+vlan.apply(egress.port, vid, vlan_ok);
+if (vlan_ok == false) {
+    egress.drop = true;
+    return;
+}
+```
+
+This is pretty much the same as what we did at the beginning of the apply block.
+Except this time, we are passing in the egress port instead of the ingress port.
+We are checking the VLAN tags not only for the ingress port, but also for the
+egress port.
+
+You can find this program in it's entirety
+[here](https://github.com/oxidecomputer/p4/blob/main/book/code/src/bin/vlan-switch.p4).
+
+## Rust Control-Plane Program
+
+The main purpose of the Rust control plane program is to manage table entries in
+the P4 program. In addition to table management, the program we'll be showing
+here also instantiates and runs the P4 code over a virtual ASIC to demonstrate
+the complete system working.
+
+We'll start top down again. Here is the beginning of our Rust program.
+
+```rust
+use tests::expect_frames;
+use tests::softnpu::{RxFrame, SoftNpu, TxFrame};
+
+p4_macro::use_p4!(
+    p4 = "book/code/src/bin/vlan-switch.p4",
+    pipeline_name = "vlan_switch"
+);
+
+fn main() -> Result<(), anyhow::Error> {
+    let mut pipeline = main_pipeline::new();
+
+    let m1 = [0x33, 0x33, 0x33, 0x33, 0x33, 0x33];
+    let m2 = [0x44, 0x44, 0x44, 0x44, 0x44, 0x44];
+
+    init_tables(&mut pipeline, m1, m2);
+    run_test(pipeline, m2)
+}
+```
+
+After imports, the first thing we are doing is calling the `use_p4!` macro. This
+translates our P4 program into Rust and expands the `use_p4!` macro in place to
+the generated Rust code. This results in the `main_pipeline` type that we see
+instantiated in the first line of the `main` program. Then we define a few MAC
+addresses that we'll get back to later. The remainder of the `main` code
+performs the two functions described above. The `init_tables` function acts as a
+control plane for our P4 code, setting up the VLAN and forwarding tables. The
+`run_test` code executes our instantiated pipeline over a virtual ASIC, sends
+some packets through it, and makes assertions about the results.
+
+### Control Plane Code
+
+Let's jump into the control plane code.
+
+```rust
+fn init_tables(pipeline: &mut main_pipeline, m1: [u8;6], m2: [u8;6]) {
+    // add static forwarding entries
+    pipeline.add_fwd_fib_entry(
+        "forward",
+        &m1,
+        &0u16.to_be_bytes()
+    );
+    pipeline.add_fwd_fib_entry(
+        "forward",
+        &m2,
+        &1u16.to_be_bytes()
+    );
+
+    // port 0 vlan 47
+    pipeline.add_vlan_port_vlan_entry(
+        "filter",
+        &0u16.to_be_bytes().to_vec(),
+        &47u16.to_be_bytes().to_vec(),
+    );
+
+    // sanity check the table
+    let x = pipeline.get_vlan_port_vlan_entries();
+    println!("{:#?}", x);
+
+    // port 1 vlan 47
+    pipeline.add_vlan_port_vlan_entry(
+        "filter",
+        &1u16.to_be_bytes().to_vec(),
+        &47u16.to_be_bytes().to_vec(),
+    );
+}
+```
+
+The first thing that happens here is the forwarding tables are set up. We add
+two entries one for each MAC address. The first MAC address maps to the first
+port and the second MAC address maps to the second port.
+
+We are using table modification methods from the Rust code that was generated
+from our P4 code. A valid question is, how do I know what these are? There are
+two ways.
+
+#### Determine Based on P4 Code Structure
+
+The naming is deterministic based on the structure of the p4 program. Table
+modification functions follow the pattern
+`<operation>_<control_path>_<table_name>_entry`. Where `operation` one of the
+following.
+
+- `add`
+- `remove`
+- `get`. 
+
+The `control_path` is based on the names of control instances starting from the
+top level ingress controller. In our P4 program, the forwarding table is named
+`fwd` so that is what we see in the function above. If there is a longer chain
+of controller instances, the instance names are underscore separated. Finally
+the `table_name` is the name of the table in the control block. This is how we
+arrive at the method name above.
+
+```rust
+pipeline.add_fwd_fib_entry(...)
+```
+
+#### Use `cargo doc`
+
+Alternatively you can just run `cargo doc` to have Cargo generate documentation
+for your crate that contains the P4-generated Rust code. This will emit Rust
+documentation that includes documentation for the generated code.
+
+Now back to the control plane code above. You'll also notice that we are adding
+key values and parameter values to the P4 tables as byte slices. At the time of
+writing, `x4c` is not generating high-level table manipulation APIs so we have
+to pass everything in as binary serialized data.
+
+The semantics of these data buffers are the following.
+
+1. Both key data and match action data (parameters) are passed in in-order.
+2. Numeric types are serialized in big-endian byte order.
+3. If a set of keys or a set of parameters results in a size that does not land
+   on a byte-boundary, i.e. 12 bytes like we have in this example, the length of
+   the buffer is rounded up to the nearest byte boundary.
+
+After adding the forwarding entries, VLAN table entries are added in the same
+manner. A VLAN with the `vid` of `47` is added to the first and second ports.
+Note that we also use a table access method to get all the entries of a table
+and print them out to convince ourselves our code is doing what we intend.
+
+### Test Code
+
+Now let's take a look at the test portion of our code.
+
+```rust
+fn run_test(pipeline: main_pipeline, m2: [u8;6]) 
+-> Result<(), anyhow::Error>
+{
+    // create and run the softnpu instance
+    let mut npu = SoftNpu::new(2, pipeline, false);
+    let phy1 = npu.phy(0);
+    let phy2 = npu.phy(1);
+    npu.run();
+
+    // send a packet we expect to make it through
+    phy1.send(&[TxFrame::newv(m2, 0, b"blueberry", 47)])?;
+    expect_frames!(phy2, &[RxFrame::newv(phy1.mac, 0x8100, b"blueberry", 47)]);
+
+    // send 3 packets, we expect the first 2 to get filtered by vlan rules
+    phy1.send(&[TxFrame::newv(m2, 0, b"poppyseed", 74)])?; // 74 != 47
+    phy1.send(&[TxFrame::new(m2, 0, b"banana")])?; // no tag
+    phy1.send(&[TxFrame::newv(m2, 0, b"muffin", 47)])?;
+    phy1.send(&[TxFrame::newv(m3, 0, b"nut", 47)])?; // no forwarding entry
+    expect_frames!(phy2, &[RxFrame::newv(phy1.mac, 0x8100, b"muffin", 47)]);
+
+    Ok(())
+}
+```
+
+The first thing we do here is create a `SoftNpu` virtual ASIC instance with 2
+ports that will execute the pipeline we configured with entries in the previous
+section. We get references to each ASIC port and run the ASIC.
+
+Next we send a few packets through the ASIC to validate that our P4 program is
+doing what we expect given how we have configured the tables.
+
+The first test passes through a packet we expect to make it through the VLAN
+filtering. The next test sends 4 packets in the ASIC, but we expect our P4
+program to filter 3 of them out.
+
+- The first packet has the wrong `vid`.
+- The second packet has no `vid`.
+- The third packet should make it through.
+- The fourth packet has no forwarding entry.
+
+#### Running the test
+
+When we run this program we see the following
+
+```bash
+$ cargo run --bin vlan-switch
+    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
+     Running `target/debug/vlan-switch`
+[
+    TableEntry {
+        action_id: "filter",
+        keyset_data: [
+            0,
+            0,
+        ],
+        parameter_data: [
+            0,
+            47,
+        ],
+    },
+]
+[phy2] blueberry
+drop
+drop
+drop
+[phy2] muffin
+```
+
+The first thing we see is our little sanity check dumping out the VLAN table
+after adding a single entry. This has what we expect, mapping the port `0` to
+the `vid` `47`.
+
+Next we start sending packets through the ASIC. There are two frame constructors
+in play here. `TxFrame::newv` creates an Ethernet frame with a VLAN header and
+`TxFrame::new` creates just a plane old Ethernet frame. The first argument to
+each frame constructor is the destination MAC address. The second argument is
+the ethertype to use and the third argument is the Ethernet payload.
+
+Next we see that our blueberry packet made it through as expected. Then we see
+three packets getting dropped as we expect. And finally we see the muffin packet
+coming through as expected.
+
+You can find this program in it's entirety
+[here](https://github.com/oxidecomputer/p4/blob/main/book/code/src/bin/vlan-switch.rs).

--- a/book/text/src/02-01-vlan-switch.md
+++ b/book/text/src/02-01-vlan-switch.md
@@ -325,22 +325,14 @@ Let's jump into the control plane code.
 ```rust
 fn init_tables(pipeline: &mut main_pipeline, m1: [u8;6], m2: [u8;6]) {
     // add static forwarding entries
-    pipeline.add_fwd_fib_entry(
-        "forward",
-        &m1,
-        &0u16.to_be_bytes()
-    );
-    pipeline.add_fwd_fib_entry(
-        "forward",
-        &m2,
-        &1u16.to_be_bytes()
-    );
+    pipeline.add_fwd_fib_entry("forward", &m1, &0u16.to_be_bytes());
+    pipeline.add_fwd_fib_entry("forward", &m2, &1u16.to_be_bytes());
 
     // port 0 vlan 47
     pipeline.add_vlan_port_vlan_entry(
         "filter",
-        &0u16.to_be_bytes().to_vec(),
-        &47u16.to_be_bytes().to_vec(),
+        0u16.to_be_bytes().as_ref(),
+        47u16.to_be_bytes().as_ref(),
     );
 
     // sanity check the table
@@ -350,9 +342,10 @@ fn init_tables(pipeline: &mut main_pipeline, m1: [u8;6], m2: [u8;6]) {
     // port 1 vlan 47
     pipeline.add_vlan_port_vlan_entry(
         "filter",
-        &1u16.to_be_bytes().to_vec(),
-        &47u16.to_be_bytes().to_vec(),
+        1u16.to_be_bytes().as_ref(),
+        47u16.to_be_bytes().as_ref(),
     );
+
 }
 ```
 
@@ -415,9 +408,11 @@ and print them out to convince ourselves our code is doing what we intend.
 Now let's take a look at the test portion of our code.
 
 ```rust
-fn run_test(pipeline: main_pipeline, m2: [u8;6]) 
--> Result<(), anyhow::Error>
-{
+fn run_test(
+    pipeline: main_pipeline,
+    m2: [u8; 6],
+    m3: [u8; 6],
+) -> Result<(), anyhow::Error> {
     // create and run the softnpu instance
     let mut npu = SoftNpu::new(2, pipeline, false);
     let phy1 = npu.phy(0);

--- a/book/text/src/02-by-example.md
+++ b/book/text/src/02-by-example.md
@@ -1,0 +1,4 @@
+# By Example
+
+This chapter presents the use of the P4 language and `x4c` through a series of
+examples. This is a living set that will grow over time.

--- a/book/text/src/SUMMARY.md
+++ b/book/text/src/SUMMARY.md
@@ -5,3 +5,5 @@
     - [Installation](./01-01-installation.md)
     - [Hello World](./01-02-hello_world.md)
     - [Compile and Run](./01-03-compile_and_run.md)
+- [By Example](./02-by-example.md)
+    - [VLAN Switch](./02-01-vlan-switch.md)

--- a/book/text/theme/highlight.js
+++ b/book/text/theme/highlight.js
@@ -53,10 +53,10 @@ const h=/\[(?:[^\\\]]|\\.)*\]|\(\??|\\([1-9][0-9]*)|\\./
 i+=a.substring(0,e.index),
 a=a.substring(e.index+e[0].length),"\\"===e[0][0]&&e[1]?i+="\\"+(Number(e[1])+n):(i+=e[0],
 "("===e[0]&&t++)}return i})).map((e=>`(${e})`)).join(n)}
-const E="[a-zA-Z]\\w*",y="[a-zA-Z_]\\w*",w="\\b\\d+(\\.\\d+)?",N="(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",v="\\b(0b[01]+)",k={
-begin:"\\\\[\\s\\S]",relevance:0},O={scope:"string",begin:"'",end:"'",
-illegal:"\\n",contains:[k]},x={scope:"string",begin:'"',end:'"',illegal:"\\n",
-contains:[k]},M=(e,n,t={})=>{const a=i({scope:"comment",begin:e,end:n,
+const E="[a-zA-Z]\\w*",y="[a-zA-Z_]\\w*",w="\\b\\d+(\\.\\d+)?",N="(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",v="\\b(0b[01]+)",O={
+begin:"\\\\[\\s\\S]",relevance:0},k={scope:"string",begin:"'",end:"'",
+illegal:"\\n",contains:[O]},x={scope:"string",begin:'"',end:'"',illegal:"\\n",
+contains:[O]},M=(e,n,t={})=>{const a=i({scope:"comment",begin:e,end:n,
 contains:[]},t);a.contains.push({scope:"doctag",
 begin:"[ ]*(?=(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):)",
 end:/(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):/,excludeBegin:!0,relevance:0})
@@ -69,14 +69,14 @@ RE_STARTERS_RE:"!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<
 SHEBANG:(e={})=>{const n=/^#![ ]*\//
 ;return e.binary&&(e.begin=m(n,/.*\b/,e.binary,/\b.*/)),i({scope:"meta",begin:n,
 end:/$/,relevance:0,"on:begin":(e,n)=>{0!==e.index&&n.ignoreMatch()}},e)},
-BACKSLASH_ESCAPE:k,APOS_STRING_MODE:O,QUOTE_STRING_MODE:x,PHRASAL_WORDS_MODE:{
+BACKSLASH_ESCAPE:O,APOS_STRING_MODE:k,QUOTE_STRING_MODE:x,PHRASAL_WORDS_MODE:{
 begin:/\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/
 },COMMENT:M,C_LINE_COMMENT_MODE:S,C_BLOCK_COMMENT_MODE:A,HASH_COMMENT_MODE:C,
 NUMBER_MODE:{scope:"number",begin:w,relevance:0},C_NUMBER_MODE:{scope:"number",
 begin:N,relevance:0},BINARY_NUMBER_MODE:{scope:"number",begin:v,relevance:0},
 REGEXP_MODE:{begin:/(?=\/[^/\n]*\/)/,contains:[{scope:"regexp",begin:/\//,
-end:/\/[gimuy]*/,illegal:/\n/,contains:[k,{begin:/\[/,end:/\]/,relevance:0,
-contains:[k]}]}]},TITLE_MODE:{scope:"title",begin:E,relevance:0},
+end:/\/[gimuy]*/,illegal:/\n/,contains:[O,{begin:/\[/,end:/\]/,relevance:0,
+contains:[O]}]}]},TITLE_MODE:{scope:"title",begin:E,relevance:0},
 UNDERSCORE_TITLE_MODE:{scope:"title",begin:y,relevance:0},METHOD_GUARD:{
 begin:"\\.\\s*[a-zA-Z_]\\w*",relevance:0},END_SAME_AS_BEGIN:e=>Object.assign(e,{
 "on:begin":(e,n)=>{n.data._beginMatch=e[1]},"on:end":(e,n)=>{
@@ -184,39 +184,39 @@ q("10.7.0","Please use highlight(code, options) instead.\nhttps://github.com/hig
 i=e,a=n),void 0===t&&(t=!0);const r={code:a,language:i};x("before:highlight",r)
 ;const s=r.result?r.result:f(r.language,r.code,t)
 ;return s.code=r.code,x("after:highlight",s),s}function f(e,n,i,r){
-const l=Object.create(null);function c(){if(!O.keywords)return void M.addText(S)
-;let e=0;O.keywordPatternRe.lastIndex=0;let n=O.keywordPatternRe.exec(S),t=""
+const l=Object.create(null);function c(){if(!k.keywords)return void M.addText(S)
+;let e=0;k.keywordPatternRe.lastIndex=0;let n=k.keywordPatternRe.exec(S),t=""
 ;for(;n;){t+=S.substring(e,n.index)
-;const i=w.case_insensitive?n[0].toLowerCase():n[0],r=(a=i,O.keywords[a]);if(r){
+;const i=w.case_insensitive?n[0].toLowerCase():n[0],r=(a=i,k.keywords[a]);if(r){
 const[e,a]=r
 ;if(M.addText(t),t="",l[i]=(l[i]||0)+1,l[i]<=7&&(A+=a),e.startsWith("_"))t+=n[0];else{
 const t=w.classNameAliases[e]||e;M.addKeyword(n[0],t)}}else t+=n[0]
-;e=O.keywordPatternRe.lastIndex,n=O.keywordPatternRe.exec(S)}var a
-;t+=S.substring(e),M.addText(t)}function g(){null!=O.subLanguage?(()=>{
-if(""===S)return;let e=null;if("string"==typeof O.subLanguage){
-if(!a[O.subLanguage])return void M.addText(S)
-;e=f(O.subLanguage,S,!0,x[O.subLanguage]),x[O.subLanguage]=e._top
-}else e=E(S,O.subLanguage.length?O.subLanguage:null)
-;O.relevance>0&&(A+=e.relevance),M.addSublanguage(e._emitter,e.language)
+;e=k.keywordPatternRe.lastIndex,n=k.keywordPatternRe.exec(S)}var a
+;t+=S.substring(e),M.addText(t)}function g(){null!=k.subLanguage?(()=>{
+if(""===S)return;let e=null;if("string"==typeof k.subLanguage){
+if(!a[k.subLanguage])return void M.addText(S)
+;e=f(k.subLanguage,S,!0,x[k.subLanguage]),x[k.subLanguage]=e._top
+}else e=E(S,k.subLanguage.length?k.subLanguage:null)
+;k.relevance>0&&(A+=e.relevance),M.addSublanguage(e._emitter,e.language)
 })():c(),S=""}function u(e,n){let t=1;const a=n.length-1;for(;t<=a;){
 if(!e._emit[t]){t++;continue}const a=w.classNameAliases[e[t]]||e[t],i=n[t]
 ;a?M.addKeyword(i,a):(S=i,c(),S=""),t++}}function b(e,n){
 return e.scope&&"string"==typeof e.scope&&M.openNode(w.classNameAliases[e.scope]||e.scope),
 e.beginScope&&(e.beginScope._wrap?(M.addKeyword(S,w.classNameAliases[e.beginScope._wrap]||e.beginScope._wrap),
-S=""):e.beginScope._multi&&(u(e.beginScope,n),S="")),O=Object.create(e,{parent:{
-value:O}}),O}function m(e,n,a){let i=((e,n)=>{const t=e&&e.exec(n)
+S=""):e.beginScope._multi&&(u(e.beginScope,n),S="")),k=Object.create(e,{parent:{
+value:k}}),k}function m(e,n,a){let i=((e,n)=>{const t=e&&e.exec(n)
 ;return t&&0===t.index})(e.endRe,a);if(i){if(e["on:end"]){const a=new t(e)
 ;e["on:end"](n,a),a.isMatchIgnored&&(i=!1)}if(i){
 for(;e.endsParent&&e.parent;)e=e.parent;return e}}
 if(e.endsWithParent)return m(e.parent,n,a)}function p(e){
-return 0===O.matcher.regexIndex?(S+=e[0],1):(R=!0,0)}function _(e){
-const t=e[0],a=n.substring(e.index),i=m(O,e,a);if(!i)return ee;const r=O
-;O.endScope&&O.endScope._wrap?(g(),
-M.addKeyword(t,O.endScope._wrap)):O.endScope&&O.endScope._multi?(g(),
-u(O.endScope,e)):r.skip?S+=t:(r.returnEnd||r.excludeEnd||(S+=t),
+return 0===k.matcher.regexIndex?(S+=e[0],1):(R=!0,0)}function _(e){
+const t=e[0],a=n.substring(e.index),i=m(k,e,a);if(!i)return ee;const r=k
+;k.endScope&&k.endScope._wrap?(g(),
+M.addKeyword(t,k.endScope._wrap)):k.endScope&&k.endScope._multi?(g(),
+u(k.endScope,e)):r.skip?S+=t:(r.returnEnd||r.excludeEnd||(S+=t),
 g(),r.excludeEnd&&(S=t));do{
-O.scope&&M.closeNode(),O.skip||O.subLanguage||(A+=O.relevance),O=O.parent
-}while(O!==i.parent);return i.starts&&b(i.starts,e),r.returnEnd?0:t.length}
+k.scope&&M.closeNode(),k.skip||k.subLanguage||(A+=k.relevance),k=k.parent
+}while(k!==i.parent);return i.starts&&b(i.starts,e),r.returnEnd?0:t.length}
 let h={};function y(a,r){const o=r&&r[0];if(S+=a,null==o)return g(),0
 ;if("begin"===h.type&&"end"===r.type&&h.index===r.index&&""===o){
 if(S+=n.slice(r.index,r.index+1),!s){const n=Error(`0 width match regex (${e})`)
@@ -227,28 +227,28 @@ const n=e[0],a=e.rule,i=new t(a),r=[a.__beforeBegin,a["on:begin"]]
 ;return a.skip?S+=n:(a.excludeBegin&&(S+=n),
 g(),a.returnBegin||a.excludeBegin||(S=n)),b(a,e),a.returnBegin?0:n.length})(r)
 ;if("illegal"===r.type&&!i){
-const e=Error('Illegal lexeme "'+o+'" for mode "'+(O.scope||"<unnamed>")+'"')
-;throw e.mode=O,e}if("end"===r.type){const e=_(r);if(e!==ee)return e}
+const e=Error('Illegal lexeme "'+o+'" for mode "'+(k.scope||"<unnamed>")+'"')
+;throw e.mode=k,e}if("end"===r.type){const e=_(r);if(e!==ee)return e}
 if("illegal"===r.type&&""===o)return 1
 ;if(T>1e5&&T>3*r.index)throw Error("potential infinite loop, way more iterations than matches")
 ;return S+=o,o.length}const w=v(e)
 ;if(!w)throw K(o.replace("{}",e)),Error('Unknown language: "'+e+'"')
-;const N=Q(w);let k="",O=r||N;const x={},M=new d.__emitter(d);(()=>{const e=[]
-;for(let n=O;n!==w;n=n.parent)n.scope&&e.unshift(n.scope)
+;const N=Q(w);let O="",k=r||N;const x={},M=new d.__emitter(d);(()=>{const e=[]
+;for(let n=k;n!==w;n=n.parent)n.scope&&e.unshift(n.scope)
 ;e.forEach((e=>M.openNode(e)))})();let S="",A=0,C=0,T=0,R=!1;try{
-for(O.matcher.considerAll();;){
-T++,R?R=!1:O.matcher.considerAll(),O.matcher.lastIndex=C
-;const e=O.matcher.exec(n);if(!e)break;const t=y(n.substring(C,e.index),e)
+for(k.matcher.considerAll();;){
+T++,R?R=!1:k.matcher.considerAll(),k.matcher.lastIndex=C
+;const e=k.matcher.exec(n);if(!e)break;const t=y(n.substring(C,e.index),e)
 ;C=e.index+t}
-return y(n.substring(C)),M.closeAllNodes(),M.finalize(),k=M.toHTML(),{
-language:e,value:k,relevance:A,illegal:!1,_emitter:M,_top:O}}catch(t){
+return y(n.substring(C)),M.closeAllNodes(),M.finalize(),O=M.toHTML(),{
+language:e,value:O,relevance:A,illegal:!1,_emitter:M,_top:k}}catch(t){
 if(t.message&&t.message.includes("Illegal"))return{language:e,value:J(n),
 illegal:!0,relevance:0,_illegalBy:{message:t.message,index:C,
-context:n.slice(C-100,C+100),mode:t.mode,resultSoFar:k},_emitter:M};if(s)return{
-language:e,value:J(n),illegal:!1,relevance:0,errorRaised:t,_emitter:M,_top:O}
+context:n.slice(C-100,C+100),mode:t.mode,resultSoFar:O},_emitter:M};if(s)return{
+language:e,value:J(n),illegal:!1,relevance:0,errorRaised:t,_emitter:M,_top:k}
 ;throw t}}function E(e,n){n=n||d.languages||Object.keys(a);const t=(e=>{
 const n={value:J(e),illegal:!1,relevance:0,_top:l,_emitter:new d.__emitter(d)}
-;return n._emitter.addText(e),n})(e),i=n.filter(v).filter(O).map((n=>f(n,e,!1)))
+;return n._emitter.addText(e),n})(e),i=n.filter(v).filter(k).map((n=>f(n,e,!1)))
 ;i.unshift(t);const r=i.sort(((e,n)=>{
 if(e.relevance!==n.relevance)return n.relevance-e.relevance
 ;if(e.language&&n.language){if(v(e.language).supersetOf===n.language)return 1
@@ -273,8 +273,8 @@ language:r.secondBest.language,relevance:r.secondBest.relevance
 }),x("after:highlightElement",{el:e,result:r,text:a})}let w=!1;function N(){
 "loading"!==document.readyState?document.querySelectorAll(d.cssSelector).forEach(y):w=!0
 }function v(e){return e=(e||"").toLowerCase(),a[e]||a[i[e]]}
-function k(e,{languageName:n}){"string"==typeof e&&(e=[e]),e.forEach((e=>{
-i[e.toLowerCase()]=n}))}function O(e){const n=v(e)
+function O(e,{languageName:n}){"string"==typeof e&&(e=[e]),e.forEach((e=>{
+i[e.toLowerCase()]=n}))}function k(e){const n=v(e)
 ;return n&&!n.disableAutodetect}function x(e,n){const t=e;r.forEach((e=>{
 e[t]&&e[t](n)}))}
 "undefined"!=typeof window&&window.addEventListener&&window.addEventListener("DOMContentLoaded",(()=>{
@@ -289,11 +289,11 @@ N(),q("10.6.0","initHighlightingOnLoad() deprecated.  Use highlightAll() now.")
 },registerLanguage:(e,t)=>{let i=null;try{i=t(n)}catch(n){
 if(K("Language definition for '{}' could not be registered.".replace("{}",e)),
 !s)throw n;K(n),i=l}
-i.name||(i.name=e),a[e]=i,i.rawDefinition=t.bind(null,n),i.aliases&&k(i.aliases,{
+i.name||(i.name=e),a[e]=i,i.rawDefinition=t.bind(null,n),i.aliases&&O(i.aliases,{
 languageName:e})},unregisterLanguage:e=>{delete a[e]
 ;for(const n of Object.keys(i))i[n]===e&&delete i[n]},
-listLanguages:()=>Object.keys(a),getLanguage:v,registerAliases:k,
-autoDetection:O,inherit:Y,addPlugin:e=>{(e=>{
+listLanguages:()=>Object.keys(a),getLanguage:v,registerAliases:O,
+autoDetection:k,inherit:Y,addPlugin:e=>{(e=>{
 e["before:highlightBlock"]&&!e["before:highlightElement"]&&(e["before:highlightElement"]=n=>{
 e["before:highlightBlock"](Object.assign({block:n.el},n))
 }),e["after:highlightBlock"]&&!e["after:highlightElement"]&&(e["after:highlightElement"]=n=>{
@@ -368,8 +368,8 @@ begin:n.concat(/\./,n.lookahead(n.concat(t,/(?![0-9A-Za-z$_(])/))),end:t,
 excludeBegin:!0,keywords:"prototype",className:"property",relevance:0},v={
 match:[/get|set/,/\s+/,t,/(?=\()/],className:{1:"keyword",3:"title.function"},
 contains:[{begin:/\(\)/},_]
-},k="(\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)|"+e.UNDERSCORE_IDENT_RE+")\\s*=>",O={
-match:[/const|var|let/,/\s+/,t,/\s*/,/=\s*/,/(async\s*)?/,n.lookahead(k)],
+},O="(\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)|"+e.UNDERSCORE_IDENT_RE+")\\s*=>",k={
+match:[/const|var|let/,/\s+/,t,/\s*/,/=\s*/,/(async\s*)?/,n.lookahead(O)],
 keywords:"async",className:{1:"keyword",3:"title.function"},contains:[_]}
 ;return{name:"Javascript",aliases:["js","jsx","mjs","cjs"],keywords:i,exports:{
 PARAMS_CONTAINS:p,CLASS_REFERENCE:f},illegal:/#(?![$_A-z])/,
@@ -377,10 +377,10 @@ contains:[e.SHEBANG({label:"shebang",binary:"node",relevance:5}),{
 label:"use_strict",className:"meta",relevance:10,
 begin:/^\s*['"]use (strict|asm)['"]/
 },e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,c,d,g,u,{match:/\$\d+/},o,f,{
-className:"attr",begin:t+n.lookahead(":"),relevance:0},O,{
+className:"attr",begin:t+n.lookahead(":"),relevance:0},k,{
 begin:"("+e.RE_STARTERS_RE+"|\\b(case|return|throw)\\b)\\s*",
 keywords:"return throw case",relevance:0,contains:[u,e.REGEXP_MODE,{
-className:"function",begin:k,returnBegin:!0,end:"\\s*=>",contains:[{
+className:"function",begin:O,returnBegin:!0,end:"\\s*=>",contains:[{
 className:"params",variants:[{begin:e.UNDERSCORE_IDENT_RE,relevance:0},{
 className:null,begin:/\(\s*\)/,skip:!0},{begin:/\(/,end:/\)/,excludeBegin:!0,
 excludeEnd:!0,keywords:i,contains:p}]}]},{begin:/,/,relevance:0},{match:/\s+/,
@@ -395,7 +395,7 @@ className:"title.function"})]},{match:/\.\.\./,relevance:0},N,{match:"\\$"+t,
 relevance:0},{match:[/\bconstructor(?=\s*\()/],className:{1:"title.function"},
 contains:[_]},y,{relevance:0,match:/\b[A-Z][A-Z_0-9]+\b/,
 className:"variable.constant"},h,v,{match:/\$[(.]/}]}}
-const Ne=e=>m(/\b/,e,/\w$/.test(e)?/\b/:/\B/),ve=["Protocol","Type"].map(Ne),ke=["init","self"].map(Ne),Oe=["Any","Self"],xe=["actor","any","associatedtype","async","await",/as\?/,/as!/,"as","break","case","catch","class","continue","convenience","default","defer","deinit","didSet","distributed","do","dynamic","else","enum","extension","fallthrough",/fileprivate\(set\)/,"fileprivate","final","for","func","get","guard","if","import","indirect","infix",/init\?/,/init!/,"inout",/internal\(set\)/,"internal","in","is","isolated","nonisolated","lazy","let","mutating","nonmutating",/open\(set\)/,"open","operator","optional","override","postfix","precedencegroup","prefix",/private\(set\)/,"private","protocol",/public\(set\)/,"public","repeat","required","rethrows","return","set","some","static","struct","subscript","super","switch","throws","throw",/try\?/,/try!/,"try","typealias",/unowned\(safe\)/,/unowned\(unsafe\)/,"unowned","var","weak","where","while","willSet"],Me=["false","nil","true"],Se=["assignment","associativity","higherThan","left","lowerThan","none","right"],Ae=["#colorLiteral","#column","#dsohandle","#else","#elseif","#endif","#error","#file","#fileID","#fileLiteral","#filePath","#function","#if","#imageLiteral","#keyPath","#line","#selector","#sourceLocation","#warn_unqualified_access","#warning"],Ce=["abs","all","any","assert","assertionFailure","debugPrint","dump","fatalError","getVaList","isKnownUniquelyReferenced","max","min","numericCast","pointwiseMax","pointwiseMin","precondition","preconditionFailure","print","readLine","repeatElement","sequence","stride","swap","swift_unboxFromSwiftValueWithType","transcode","type","unsafeBitCast","unsafeDowncast","withExtendedLifetime","withUnsafeMutablePointer","withUnsafePointer","withVaList","withoutActuallyEscaping","zip"],Te=p(/[/=\-+!*%<>&|^~?]/,/[\u00A1-\u00A7]/,/[\u00A9\u00AB]/,/[\u00AC\u00AE]/,/[\u00B0\u00B1]/,/[\u00B6\u00BB\u00BF\u00D7\u00F7]/,/[\u2016-\u2017]/,/[\u2020-\u2027]/,/[\u2030-\u203E]/,/[\u2041-\u2053]/,/[\u2055-\u205E]/,/[\u2190-\u23FF]/,/[\u2500-\u2775]/,/[\u2794-\u2BFF]/,/[\u2E00-\u2E7F]/,/[\u3001-\u3003]/,/[\u3008-\u3020]/,/[\u3030]/),Re=p(Te,/[\u0300-\u036F]/,/[\u1DC0-\u1DFF]/,/[\u20D0-\u20FF]/,/[\uFE00-\uFE0F]/,/[\uFE20-\uFE2F]/),De=m(Te,Re,"*"),Ie=p(/[a-zA-Z_]/,/[\u00A8\u00AA\u00AD\u00AF\u00B2-\u00B5\u00B7-\u00BA]/,/[\u00BC-\u00BE\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]/,/[\u0100-\u02FF\u0370-\u167F\u1681-\u180D\u180F-\u1DBF]/,/[\u1E00-\u1FFF]/,/[\u200B-\u200D\u202A-\u202E\u203F-\u2040\u2054\u2060-\u206F]/,/[\u2070-\u20CF\u2100-\u218F\u2460-\u24FF\u2776-\u2793]/,/[\u2C00-\u2DFF\u2E80-\u2FFF]/,/[\u3004-\u3007\u3021-\u302F\u3031-\u303F\u3040-\uD7FF]/,/[\uF900-\uFD3D\uFD40-\uFDCF\uFDF0-\uFE1F\uFE30-\uFE44]/,/[\uFE47-\uFEFE\uFF00-\uFFFD]/),Le=p(Ie,/\d/,/[\u0300-\u036F\u1DC0-\u1DFF\u20D0-\u20FF\uFE20-\uFE2F]/),Be=m(Ie,Le,"*"),$e=m(/[A-Z]/,Le,"*"),ze=["autoclosure",m(/convention\(/,p("swift","block","c"),/\)/),"discardableResult","dynamicCallable","dynamicMemberLookup","escaping","frozen","GKInspectable","IBAction","IBDesignable","IBInspectable","IBOutlet","IBSegueAction","inlinable","main","nonobjc","NSApplicationMain","NSCopying","NSManaged",m(/objc\(/,Be,/\)/),"objc","objcMembers","propertyWrapper","requires_stored_property_inits","resultBuilder","testable","UIApplicationMain","unknown","usableFromInline"],Fe=["iOS","iOSApplicationExtension","macOS","macOSApplicationExtension","macCatalyst","macCatalystApplicationExtension","watchOS","watchOSApplicationExtension","tvOS","tvOSApplicationExtension","swift"]
+const Ne=e=>m(/\b/,e,/\w$/.test(e)?/\b/:/\B/),ve=["Protocol","Type"].map(Ne),Oe=["init","self"].map(Ne),ke=["Any","Self"],xe=["actor","any","associatedtype","async","await",/as\?/,/as!/,"as","break","case","catch","class","continue","convenience","default","defer","deinit","didSet","distributed","do","dynamic","else","enum","extension","fallthrough",/fileprivate\(set\)/,"fileprivate","final","for","func","get","guard","if","import","indirect","infix",/init\?/,/init!/,"inout",/internal\(set\)/,"internal","in","is","isolated","nonisolated","lazy","let","mutating","nonmutating",/open\(set\)/,"open","operator","optional","override","postfix","precedencegroup","prefix",/private\(set\)/,"private","protocol",/public\(set\)/,"public","repeat","required","rethrows","return","set","some","static","struct","subscript","super","switch","throws","throw",/try\?/,/try!/,"try","typealias",/unowned\(safe\)/,/unowned\(unsafe\)/,"unowned","var","weak","where","while","willSet"],Me=["false","nil","true"],Se=["assignment","associativity","higherThan","left","lowerThan","none","right"],Ae=["#colorLiteral","#column","#dsohandle","#else","#elseif","#endif","#error","#file","#fileID","#fileLiteral","#filePath","#function","#if","#imageLiteral","#keyPath","#line","#selector","#sourceLocation","#warn_unqualified_access","#warning"],Ce=["abs","all","any","assert","assertionFailure","debugPrint","dump","fatalError","getVaList","isKnownUniquelyReferenced","max","min","numericCast","pointwiseMax","pointwiseMin","precondition","preconditionFailure","print","readLine","repeatElement","sequence","stride","swap","swift_unboxFromSwiftValueWithType","transcode","type","unsafeBitCast","unsafeDowncast","withExtendedLifetime","withUnsafeMutablePointer","withUnsafePointer","withVaList","withoutActuallyEscaping","zip"],Te=p(/[/=\-+!*%<>&|^~?]/,/[\u00A1-\u00A7]/,/[\u00A9\u00AB]/,/[\u00AC\u00AE]/,/[\u00B0\u00B1]/,/[\u00B6\u00BB\u00BF\u00D7\u00F7]/,/[\u2016-\u2017]/,/[\u2020-\u2027]/,/[\u2030-\u203E]/,/[\u2041-\u2053]/,/[\u2055-\u205E]/,/[\u2190-\u23FF]/,/[\u2500-\u2775]/,/[\u2794-\u2BFF]/,/[\u2E00-\u2E7F]/,/[\u3001-\u3003]/,/[\u3008-\u3020]/,/[\u3030]/),Re=p(Te,/[\u0300-\u036F]/,/[\u1DC0-\u1DFF]/,/[\u20D0-\u20FF]/,/[\uFE00-\uFE0F]/,/[\uFE20-\uFE2F]/),De=m(Te,Re,"*"),Ie=p(/[a-zA-Z_]/,/[\u00A8\u00AA\u00AD\u00AF\u00B2-\u00B5\u00B7-\u00BA]/,/[\u00BC-\u00BE\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]/,/[\u0100-\u02FF\u0370-\u167F\u1681-\u180D\u180F-\u1DBF]/,/[\u1E00-\u1FFF]/,/[\u200B-\u200D\u202A-\u202E\u203F-\u2040\u2054\u2060-\u206F]/,/[\u2070-\u20CF\u2100-\u218F\u2460-\u24FF\u2776-\u2793]/,/[\u2C00-\u2DFF\u2E80-\u2FFF]/,/[\u3004-\u3007\u3021-\u302F\u3031-\u303F\u3040-\uD7FF]/,/[\uF900-\uFD3D\uFD40-\uFDCF\uFDF0-\uFE1F\uFE30-\uFE44]/,/[\uFE47-\uFEFE\uFF00-\uFFFD]/),Le=p(Ie,/\d/,/[\u0300-\u036F\u1DC0-\u1DFF\u20D0-\u20FF\uFE20-\uFE2F]/),Be=m(Ie,Le,"*"),$e=m(/[A-Z]/,Le,"*"),ze=["autoclosure",m(/convention\(/,p("swift","block","c"),/\)/),"discardableResult","dynamicCallable","dynamicMemberLookup","escaping","frozen","GKInspectable","IBAction","IBDesignable","IBInspectable","IBOutlet","IBSegueAction","inlinable","main","nonobjc","NSApplicationMain","NSCopying","NSManaged",m(/objc\(/,Be,/\)/),"objc","objcMembers","propertyWrapper","requires_stored_property_inits","resultBuilder","testable","UIApplicationMain","unknown","usableFromInline"],Fe=["iOS","iOSApplicationExtension","macOS","macOSApplicationExtension","macCatalyst","macCatalystApplicationExtension","watchOS","watchOSApplicationExtension","tvOS","tvOSApplicationExtension","swift"]
 ;var Ue=Object.freeze({__proto__:null,grmr_bash:e=>{const n=e.regex,t={},a={
 begin:/\$\{/,end:/\}/,contains:["self",{begin:/:-/,contains:[t]}]}
 ;Object.assign(t,{className:"variable",variants:[{
@@ -797,20 +797,20 @@ className:"string"}),{className:"string",begin:/<.*?>/,end:/$/,illegal:"\\n"
 },e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{className:"class",
 begin:"("+t.keyword.join("|")+")\\b",end:/(\{|$)/,excludeEnd:!0,keywords:t,
 contains:[e.UNDERSCORE_TITLE_MODE]},{begin:"\\."+e.UNDERSCORE_IDENT_RE,
-relevance:0}]}},grmr_p4:e=>{e.regex,e.COMMENT("//","$",{contains:[{begin:/\\\n/
-}]});const n={
+relevance:0}]}},grmr_p4:e=>{e.regex;const n=e.COMMENT("//","$",{contains:[{
+begin:/\\\n/}]}),t={
 keyword:["parser","control","state","in","out","inout","transition","struct","header","default_action","action","key","actions","entries","const","table","apply","exact","lpm","ternary","range","if","else"],
 type:["bit","packet_in"],literal:"true false"};return{name:"P4",aliases:[],
-keywords:n,disableAutodetect:!0,illegal:"</",contains:[].concat([{
+keywords:t,disableAutodetect:!0,illegal:"</",contains:[].concat([{
 className:"type",variants:[{match:/[a-z\d_]*_[th]\s/}]},{className:"function",
 variants:[{match:/state [a-z\d_]*/}],keywords:{literal:"state"}},{
 className:"function",variants:[{match:/\saction [a-z\d_]*/}],keywords:{
 literal:"action default_action"}},{className:"number",variants:[{
-begin:"\\b(0b[01']+)"},{begin:/([1-9][0-9]*w\d+)/},{
+begin:"\\b(0b[01']+)"},{begin:/([1-9][0-9]*w(0x)?\d+)/},{
 begin:"(-?)\\b([\\d']+(\\.[\\d']*)?|\\.[\\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)"
 },{
 begin:"(-?)(\\b0[xX][a-fA-F0-9']+|(\\b[\\d']+(\\.[\\d']*)?|\\.[\\d']+)([eE][-+]?[\\d']+)?)"
-}],relevance:0}]),exports:{keywords:n}}},grmr_perl:e=>{
+}],relevance:0},n,e.C_BLOCK_COMMENT_MODE]),exports:{keywords:t}}},grmr_perl:e=>{
 const n=e.regex,t=/[dualxmsipngr]{0,12}/,a={$pattern:/[\w.]+/,
 keyword:"abs accept alarm and atan2 bind binmode bless break caller chdir chmod chomp chop chown chr chroot close closedir connect continue cos crypt dbmclose dbmopen defined delete die do dump each else elsif endgrent endhostent endnetent endprotoent endpwent endservent eof eval exec exists exit exp fcntl fileno flock for foreach fork format formline getc getgrent getgrgid getgrnam gethostbyaddr gethostbyname gethostent getlogin getnetbyaddr getnetbyname getnetent getpeername getpgrp getpriority getprotobyname getprotobynumber getprotoent getpwent getpwnam getpwuid getservbyname getservbyport getservent getsockname getsockopt given glob gmtime goto grep gt hex if index int ioctl join keys kill last lc lcfirst length link listen local localtime log lstat lt ma map mkdir msgctl msgget msgrcv msgsnd my ne next no not oct open opendir or ord our pack package pipe pop pos print printf prototype push q|0 qq quotemeta qw qx rand read readdir readline readlink readpipe recv redo ref rename require reset return reverse rewinddir rindex rmdir say scalar seek seekdir select semctl semget semop send setgrent sethostent setnetent setpgrp setpriority setprotoent setpwent setservent setsockopt shift shmctl shmget shmread shmwrite shutdown sin sleep socket socketpair sort splice split sprintf sqrt srand stat state study sub substr symlink syscall sysopen sysread sysseek system syswrite tell telldir tie tied time times tr truncate uc ucfirst umask undef unless unlink unpack unshift untie until use utime values vec wait waitpid wantarray warn when while write x|0 xor y|0"
 },i={className:"subst",begin:"[$@]\\{",end:"\\}",keywords:a},r={begin:/->\{/,
@@ -1085,11 +1085,11 @@ begin:/'/,end:/'/,contains:[{begin:/''/}]}]},{begin:/"/,end:/"/,contains:[{
 begin:/""/}]},e.C_NUMBER_MODE,e.C_BLOCK_COMMENT_MODE,t,{className:"operator",
 begin:/[-+*/=%^~]|&&?|\|\|?|!=?|<(?:=>?|<|>)?|>[>=]?/,relevance:0}]}},
 grmr_swift:e=>{const n={match:/\s+/,relevance:0},t=e.COMMENT("/\\*","\\*/",{
-contains:["self"]}),a=[e.C_LINE_COMMENT_MODE,t],i={match:[/\./,p(...ve,...ke)],
+contains:["self"]}),a=[e.C_LINE_COMMENT_MODE,t],i={match:[/\./,p(...ve,...Oe)],
 className:{2:"keyword"}},r={match:m(/\./,p(...xe)),relevance:0
 },s=xe.filter((e=>"string"==typeof e)).concat(["_|0"]),o={variants:[{
 className:"keyword",
-match:p(...xe.filter((e=>"string"!=typeof e)).concat(Oe).map(Ne),...ke)}]},l={
+match:p(...xe.filter((e=>"string"!=typeof e)).concat(ke).map(Ne),...Oe)}]},l={
 $pattern:p(/\b\w+/,/#\w+/),keyword:s.concat(Ae),literal:Me},c=[i,r,o],d=[{
 match:m(/\./,p(...Ce)),relevance:0},{className:"built_in",
 match:m(/\b/,p(...Ce),/(?=\()/)}],u={match:/->/,relevance:0},b=[u,{
@@ -1104,8 +1104,8 @@ match:m(/\\/,e,/[\t ]*(?:[\r\n]|\r\n)/)}),y=(e="")=>({className:"subst",
 label:"interpol",begin:m(/\\/,e,/\(/),end:/\)/}),w=(e="")=>({begin:m(e,/"""/),
 end:m(/"""/,e),contains:[f(e),E(e),y(e)]}),N=(e="")=>({begin:m(e,/"/),
 end:m(/"/,e),contains:[f(e),y(e)]}),v={className:"string",
-variants:[w(),w("#"),w("##"),w("###"),N(),N("#"),N("##"),N("###")]},k={
-match:m(/`/,Be,/`/)},O=[k,{className:"variable",match:/\$\d+/},{
+variants:[w(),w("#"),w("##"),w("###"),N(),N("#"),N("##"),N("###")]},O={
+match:m(/`/,Be,/`/)},k=[O,{className:"variable",match:/\$\d+/},{
 className:"variable",match:`\\$${Le}+`}],x=[{match:/(@|#(un)?)available/,
 className:"keyword",starts:{contains:[{begin:/\(/,end:/\)/,keywords:Fe,
 contains:[...b,h,v]}]}},{className:"keyword",match:m(/@/,p(...ze))},{
@@ -1117,25 +1117,25 @@ match:/\.\.\./,relevance:0},{match:m(/\s+&\s+/,g($e)),relevance:0}]},S={
 begin:/</,end:/>/,keywords:l,contains:[...a,...c,...x,u,M]};M.contains.push(S)
 ;const A={begin:/\(/,end:/\)/,relevance:0,keywords:l,contains:["self",{
 match:m(Be,/\s*:/),keywords:"_|0",relevance:0
-},...a,...c,...d,...b,h,v,...O,...x,M]},C={begin:/</,end:/>/,contains:[...a,M]
+},...a,...c,...d,...b,h,v,...k,...x,M]},C={begin:/</,end:/>/,contains:[...a,M]
 },T={begin:/\(/,end:/\)/,keywords:l,contains:[{
 begin:p(g(m(Be,/\s*:/)),g(m(Be,/\s+/,Be,/\s*:/))),end:/:/,relevance:0,
 contains:[{className:"keyword",match:/\b_\b/},{className:"params",match:Be}]
 },...a,...c,...b,h,v,...x,M,A],endsParent:!0,illegal:/["']/},R={
-match:[/func/,/\s+/,p(k.match,Be,De)],className:{1:"keyword",3:"title.function"
+match:[/func/,/\s+/,p(O.match,Be,De)],className:{1:"keyword",3:"title.function"
 },contains:[C,T,n],illegal:[/\[/,/%/]},D={
 match:[/\b(?:subscript|init[?!]?)/,/\s*(?=[<(])/],className:{1:"keyword"},
 contains:[C,T,n],illegal:/\[|%/},I={match:[/operator/,/\s+/,De],className:{
 1:"keyword",3:"title"}},L={begin:[/precedencegroup/,/\s+/,$e],className:{
 1:"keyword",3:"title"},contains:[M],keywords:[...Se,...Me],end:/}/}
 ;for(const e of v.variants){const n=e.contains.find((e=>"interpol"===e.label))
-;n.keywords=l;const t=[...c,...d,...b,h,v,...O];n.contains=[...t,{begin:/\(/,
+;n.keywords=l;const t=[...c,...d,...b,h,v,...k];n.contains=[...t,{begin:/\(/,
 end:/\)/,contains:["self",...t]}]}return{name:"Swift",keywords:l,
 contains:[...a,R,D,{beginKeywords:"struct protocol class extension enum actor",
 end:"\\{",excludeEnd:!0,keywords:l,contains:[e.inherit(e.TITLE_MODE,{
 className:"title.class",begin:/[A-Za-z$_][\u00C0-\u02B80-9A-Za-z$_]*/}),...c]
 },I,L,{beginKeywords:"import",end:/$/,contains:[...a],relevance:0
-},...c,...d,...b,h,v,...O,...x,M,A]}},grmr_typescript:e=>{
+},...c,...d,...b,h,v,...k,...x,M,A]}},grmr_typescript:e=>{
 const n=we(e),t=["any","void","number","boolean","string","object","never","symbol","bigint","unknown"],a={
 beginKeywords:"namespace",end:/\{/,excludeEnd:!0,
 contains:[n.exports.CLASS_REFERENCE]},i={beginKeywords:"interface",end:/\{/,

--- a/codegen/rust/src/control.rs
+++ b/codegen/rust/src/control.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use p4::ast::{
     Action, Control, ControlParameter, Direction, ExpressionKind,
-    KeySetElementValue, MatchKind, Statement, Table, Type, AST,
+    KeySetElementValue, MatchKind, Table, Type, AST,
 };
 use p4::hlir::Hlir;
 use p4::util::resolve_lvalue;
@@ -448,21 +448,6 @@ impl<'a> ControlGenerator<'a> {
         (table_type, tokens)
     }
 
-    fn generate_control_apply_stmt(
-        &mut self,
-        control: &Control,
-        stmt: &Statement,
-        tokens: &mut TokenStream,
-    ) {
-        let mut names = control.names();
-        let sg = StatementGenerator::new(
-            self.ast,
-            self.hlir,
-            StatementContext::Control(control),
-        );
-        tokens.extend(sg.generate_statement(stmt, &mut names));
-    }
-
     fn generate_control_apply_body(
         &mut self,
         control: &Control,
@@ -483,9 +468,14 @@ impl<'a> ControlGenerator<'a> {
             }
         }
 
-        for stmt in &control.apply.statements {
-            self.generate_control_apply_stmt(control, stmt, &mut tokens);
-        }
+        let mut names = control.names();
+        let sg = StatementGenerator::new(
+            self.ast,
+            self.hlir,
+            StatementContext::Control(control),
+        );
+        tokens.extend(sg.generate_block(&control.apply, &mut names));
+
         tokens
     }
 

--- a/codegen/rust/src/control.rs
+++ b/codegen/rust/src/control.rs
@@ -208,13 +208,14 @@ impl<'a> ControlGenerator<'a> {
         }
         //let dump_fmt = vec!["{}"; action.parameters.len()];
         let dump_fmt = dump_fmt.join(", ");
-        let dump_args: Vec<TokenStream> = action.parameters
+        let dump_args: Vec<TokenStream> = action
+            .parameters
             .iter()
             .map(|x| format_ident!("{}", x.name.clone()))
-            .map(|x| quote!{ #x })
+            .map(|x| quote! { #x })
             .collect();
 
-        let dump = quote!{
+        let dump = quote! {
             // TODO find a way to only allocate the string when probe is active.
             // Cannot simply return reference to string created within probe.
             let dump = format!(#dump_fmt, #(#dump_args,)*);

--- a/codegen/rust/src/expression.rs
+++ b/codegen/rust/src/expression.rs
@@ -47,12 +47,18 @@ impl<'a> ExpressionGenerator<'a> {
                                     .hlir
                                     .lvalue_decls
                                     .get(lval)
-                                    .unwrap_or_else(||
-                                        panic!("declaration info for {:#?}", lval));
+                                    .unwrap_or_else(|| {
+                                        panic!(
+                                            "declaration info for {:#?}",
+                                            lval
+                                        )
+                                    });
                                 match name_info.decl {
-                                    DeclarationInfo::ActionParameter(_) => quote! {
-                                        &#lhs_tks
-                                    },
+                                    DeclarationInfo::ActionParameter(_) => {
+                                        quote! {
+                                            &#lhs_tks
+                                        }
+                                    }
                                     _ => lhs_tks,
                                 }
                             }
@@ -64,20 +70,26 @@ impl<'a> ExpressionGenerator<'a> {
                                     .hlir
                                     .lvalue_decls
                                     .get(lval)
-                                    .unwrap_or_else(||
-                                        panic!("declaration info for {:#?}", lval));
+                                    .unwrap_or_else(|| {
+                                        panic!(
+                                            "declaration info for {:#?}",
+                                            lval
+                                        )
+                                    });
                                 match name_info.decl {
-                                    DeclarationInfo::ActionParameter(_) => quote! {
-                                        &#rhs_tks
-                                    },
+                                    DeclarationInfo::ActionParameter(_) => {
+                                        quote! {
+                                            &#rhs_tks
+                                        }
+                                    }
                                     _ => rhs_tks,
                                 }
                             }
                             _ => rhs_tks,
                         };
-                        ts.extend(lhs_tks_.clone());
+                        ts.extend(lhs_tks_);
                         ts.extend(op_tks);
-                        ts.extend(rhs_tks_.clone());
+                        ts.extend(rhs_tks_);
                     }
                     _ => {
                         ts.extend(lhs_tks);

--- a/codegen/rust/src/lib.rs
+++ b/codegen/rust/src/lib.rs
@@ -190,6 +190,7 @@ fn dtrace_probes() -> TokenStream {
             fn control_accepted(_: &str) {}
             fn control_table_hit(_: &str) {}
             fn control_table_miss(_: &str) {}
+            fn action(_: &str) {}
         }
     }
 }
@@ -360,6 +361,7 @@ fn is_rust_reference(lval: &Lvalue, names: &HashMap<String, NameInfo>) -> bool {
             DeclarationInfo::ControlMember => false,
             DeclarationInfo::State => false,
             DeclarationInfo::Action => false,
+            DeclarationInfo::ActionParameter(_) => false,
         }
     } else {
         false

--- a/codegen/rust/src/lib.rs
+++ b/codegen/rust/src/lib.rs
@@ -285,6 +285,15 @@ fn type_size(ty: &Type, ast: &AST) -> usize {
     }
 }
 
+fn type_size_bytes(ty: &Type, ast: &AST) -> usize {
+    let s = type_size(ty, ast);
+    let mut b = s >> 3;
+    if s % 8 != 0 {
+        b += 1
+    }
+    b
+}
+
 // in the case of an expression
 //
 //   a &&& b

--- a/codegen/rust/src/lib.rs
+++ b/codegen/rust/src/lib.rs
@@ -10,7 +10,7 @@ use quote::{format_ident, quote};
 use p4::ast::{
     Control, ControlParameter, DeclarationInfo, Direction, Expression,
     ExpressionKind, Lvalue, NameInfo, Parser, Table, Type, UserDefinedType,
-    AST,
+    HeaderMember, MutVisitor, StructMember, ActionParameter, AST,
 };
 use p4::hlir::Hlir;
 use p4::util::resolve_lvalue;
@@ -47,24 +47,41 @@ pub struct Settings {
     pub pipeline_name: String,
 }
 
-pub fn sanitize(ast: &mut AST) {
-    for h in &mut ast.headers {
-        for m in &mut h.members {
-            sanitize_string(&mut m.name);
+pub struct Sanitizer {}
+
+impl Sanitizer {
+    pub fn sanitize_string(s: &mut String) {
+        //TODO sanitize other problematic rust tokens
+        if s == "type" {
+            *s = "typ".to_owned();
         }
-    }
-    for s in &mut ast.structs {
-        for m in &mut s.members {
-            sanitize_string(&mut m.name);
+        if s == "match" {
+            *s = "match_".to_owned();
         }
     }
 }
 
-pub fn sanitize_string(s: &mut String) {
-    //TODO sanitize other problematic rust tokens
-    if s == "type" {
-        *s = "typ".to_owned();
+impl MutVisitor for Sanitizer {
+    fn struct_member(&self, m: &mut StructMember) {
+        Self::sanitize_string(&mut m.name);
     }
+    fn header_member(&self, m: &mut HeaderMember) {
+        Self::sanitize_string(&mut m.name);
+    }
+    fn control_parameter(&self, p: &mut ControlParameter) {
+        Self::sanitize_string(&mut p.name);
+    }
+    fn action_parameter(&self, p: &mut ActionParameter) {
+        Self::sanitize_string(&mut p.name);
+    }
+    fn lvalue(&self, lv: &mut Lvalue) {
+        Self::sanitize_string(&mut lv.name);
+    }
+}
+
+pub fn sanitize(ast: &mut AST) {
+    let s = Sanitizer{};
+    ast.accept_mut(&s);
 }
 
 pub fn emit(

--- a/codegen/rust/src/lib.rs
+++ b/codegen/rust/src/lib.rs
@@ -8,9 +8,9 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use p4::ast::{
-    Control, ControlParameter, DeclarationInfo, Direction, Expression,
-    ExpressionKind, Lvalue, NameInfo, Parser, Table, Type, UserDefinedType,
-    HeaderMember, MutVisitor, StructMember, ActionParameter, AST,
+    ActionParameter, Control, ControlParameter, DeclarationInfo, Direction,
+    Expression, ExpressionKind, HeaderMember, Lvalue, MutVisitor, NameInfo,
+    Parser, StructMember, Table, Type, UserDefinedType, AST,
 };
 use p4::hlir::Hlir;
 use p4::util::resolve_lvalue;
@@ -80,7 +80,7 @@ impl MutVisitor for Sanitizer {
 }
 
 pub fn sanitize(ast: &mut AST) {
-    let s = Sanitizer{};
+    let s = Sanitizer {};
     ast.accept_mut(&s);
 }
 

--- a/codegen/rust/src/lib.rs
+++ b/codegen/rust/src/lib.rs
@@ -230,6 +230,9 @@ fn rust_type(ty: &Type) -> TokenStream {
         Type::State => {
             todo!("rust type for state");
         }
+        Type::Action => {
+            todo!("rust type for action");
+        }
     }
 }
 
@@ -275,6 +278,9 @@ fn type_size(ty: &Type, ast: &AST) -> usize {
         Type::List(_) => todo!("type size for list"),
         Type::State => {
             todo!("type size for state");
+        }
+        Type::Action => {
+            todo!("type size for action");
         }
     }
 }
@@ -344,6 +350,7 @@ fn is_rust_reference(lval: &Lvalue, names: &HashMap<String, NameInfo>) -> bool {
             DeclarationInfo::ControlTable => false,
             DeclarationInfo::ControlMember => false,
             DeclarationInfo::State => false,
+            DeclarationInfo::Action => false,
         }
     } else {
         false

--- a/codegen/rust/src/pipeline.rs
+++ b/codegen/rust/src/pipeline.rs
@@ -1,8 +1,8 @@
 // Copyright 2022 Oxide Computer Company
 
 use crate::{
-    qualified_table_function_name, qualified_table_name, rust_type, type_size,
-    Context, Settings,
+    qualified_table_function_name, qualified_table_name, rust_type,
+    type_size_bytes, Context, Settings,
 };
 use p4::ast::{
     Control, Direction, MatchKind, PackageInstance, Parser, Table, Type, AST,
@@ -419,7 +419,7 @@ impl<'a> PipelineGenerator<'a> {
                 self.hlir.lvalue_decls.get(lval).unwrap_or_else(|| {
                     panic!("declaration info for {:#?}", lval,)
                 });
-            let sz = type_size(&name_info.ty, self.ast) >> 3;
+            let sz = type_size_bytes(&name_info.ty, self.ast);
             match match_kind {
                 MatchKind::Exact => keys.push(quote! {
                     p4rs::extract_exact_key(

--- a/codegen/rust/src/pipeline.rs
+++ b/codegen/rust/src/pipeline.rs
@@ -500,6 +500,9 @@ impl<'a> PipelineGenerator<'a> {
                     Type::State => {
                         todo!();
                     }
+                    Type::Action => {
+                        todo!();
+                    }
                     Type::Bit(n) => {
                         parameter_tokens.push(quote! {
                             let #pname = p4rs::extract_bit_action_parameter(

--- a/codegen/rust/src/statement.rs
+++ b/codegen/rust/src/statement.rs
@@ -385,18 +385,14 @@ impl<'a> StatementGenerator<'a> {
                 let et = self.hlir.expression_types.get(a.as_ref()).unwrap();
                 // if the argument is an lvalue and a rust type that gets passed
                 // by reference, take a ref
-                match a.as_ref().kind {
-                    ExpressionKind::Lvalue(_) => {
-                        match et {
-                            Type::Bit(_) | Type::Varbit(_) | Type::Int(_) => {
-                                arg_xpr = quote!{ &#arg_xpr };
-                            }
-                            _ => {}
+                if let ExpressionKind::Lvalue(_) = a.as_ref().kind {
+                    match et {
+                        Type::Bit(_) | Type::Varbit(_) | Type::Int(_) => {
+                            arg_xpr = quote! { &#arg_xpr };
                         }
+                        _ => {}
                     }
-                    _ => {}
                 }
-
                 let local_name = format_ident!("arg{}", i);
                 if let ExpressionKind::BitLit(_, _) = a.as_ref().kind {
                     locals.push(quote! {

--- a/lang/p4rs/src/lib.rs
+++ b/lang/p4rs/src/lib.rs
@@ -348,9 +348,12 @@ pub fn extract_bit_action_parameter(
     offset: usize,
     size: usize,
 ) -> BitVec<u8, Msb0> {
-    let size = size >> 3;
+    let mut byte_size = size >> 3;
+    if size % 8 != 0 {
+        byte_size += 1;
+    }
     let b: BitVec<u8, Msb0> =
-        BitVec::from_slice(&parameter_data[offset..offset + size]);
+        BitVec::from_slice(&parameter_data[offset..offset + byte_size]);
 
     // NOTE this barfing and then unbarfing a vec is to handle the p4
     // confused-endian data model.

--- a/lang/p4rs/src/table.rs
+++ b/lang/p4rs/src/table.rs
@@ -200,7 +200,13 @@ pub fn sort_entries_by_priority<const D: usize, A: Clone>(
 
 pub fn key_matches(selector: &BigUint, key: &Key) -> bool {
     match key {
-        Key::Exact(x) => selector == &x.value,
+        Key::Exact(x) => {
+            let hit = selector == &x.value;
+            if !hit {
+                //println!("{:x} != {:x}", selector, x.value);
+            }
+            hit
+        }
         Key::Range(begin, end) => {
             selector >= &begin.value && selector <= &end.value
         }

--- a/p4/src/ast.rs
+++ b/p4/src/ast.rs
@@ -211,6 +211,7 @@ pub enum Type {
     Void,
     List(Vec<Box<Type>>),
     State,
+    Action,
 }
 
 impl Type {
@@ -246,6 +247,7 @@ impl fmt::Display for Type {
             Type::Table => write!(f, "table"),
             Type::Void => write!(f, "void"),
             Type::State => write!(f, "state"),
+            Type::Action => write!(f, "action"),
             Type::List(elems) => {
                 write!(f, "list<")?;
                 for e in elems {
@@ -680,6 +682,15 @@ impl Control {
                 NameInfo {
                     ty: c.ty.clone(),
                     decl: DeclarationInfo::ControlMember,
+                },
+            );
+        }
+        for a in &self.actions {
+            names.insert(
+                a.name.clone(),
+                NameInfo {
+                    ty: Type::Action,
+                    decl: DeclarationInfo::Action,
                 },
             );
         }
@@ -1516,6 +1527,7 @@ pub enum DeclarationInfo {
     ControlTable,
     ControlMember,
     State,
+    Action,
 }
 
 #[derive(Debug, Clone)]

--- a/p4/src/ast.rs
+++ b/p4/src/ast.rs
@@ -895,7 +895,7 @@ impl Action {
                 p.name.clone(),
                 NameInfo {
                     ty: p.ty.clone(),
-                    decl: DeclarationInfo::Parameter(p.direction),
+                    decl: DeclarationInfo::ActionParameter(p.direction),
                 },
             );
         }
@@ -1528,6 +1528,7 @@ pub enum DeclarationInfo {
     ControlMember,
     State,
     Action,
+    ActionParameter(Direction),
 }
 
 #[derive(Debug, Clone)]

--- a/p4/src/check.rs
+++ b/p4/src/check.rs
@@ -197,11 +197,8 @@ impl ControlChecker {
         diags: &mut Diagnostics,
     ) {
         for s in &c.apply.statements {
-            match s {
-                Statement::Call(call) => {
-                    Self::check_apply_call(c, call, ast, hlir, diags);
-                }
-                _ => {}
+            if let Statement::Call(call) = s {
+                Self::check_apply_call(c, call, ast, hlir, diags);
             }
         }
     }
@@ -218,7 +215,7 @@ impl ControlChecker {
         let name_info = match names.get(name) {
             Some(info) => info,
             None => {
-                diags.push(Diagnostic{
+                diags.push(Diagnostic {
                     level: Level::Error,
                     message: format!("{} is undefined", name),
                     token: call.lval.token.clone(),
@@ -229,22 +226,21 @@ impl ControlChecker {
 
         match &name_info.ty {
             Type::UserDefined(name) => {
-                if let Some(ctl) = ast.get_control(&name) {
-                    return Self::check_apply_ctl_apply(
-                        c, call, ctl, ast, hlir, diags);
+                if let Some(ctl) = ast.get_control(name) {
+                    Self::check_apply_ctl_apply(c, call, ctl, ast, hlir, diags)
                 }
             }
             Type::Table => {
                 if let Some(tbl) = c.get_table(name) {
-                    return Self::check_apply_table_apply(
-                        c, call, tbl, ast, hlir, diags);
+                    Self::check_apply_table_apply(
+                        c, call, tbl, ast, hlir, diags,
+                    )
                 }
             }
             _ => {
                 //TODO
             }
         }
-
     }
 
     pub fn check_apply_table_apply(
@@ -266,12 +262,11 @@ impl ControlChecker {
         hlir: &Hlir,
         diags: &mut Diagnostics,
     ) {
-
         //todo!("check apply ctl");
 
         if call.args.len() != ctl.parameters.len() {
-
-            let signature: Vec<String> = ctl.parameters
+            let signature: Vec<String> = ctl
+                .parameters
                 .iter()
                 .map(|x| x.ty.to_string().bright_blue().to_string())
                 .collect();
@@ -294,13 +289,13 @@ impl ControlChecker {
         }
 
         for (i, arg) in call.args.iter().enumerate() {
-            let arg_t = match hlir.expression_types.get(&*arg) {
+            let arg_t = match hlir.expression_types.get(arg) {
                 Some(typ) => typ,
-                None => panic!("bug: no type for expression {:?}", &*arg),
+                None => panic!("bug: no type for expression {:?}", arg),
             };
             let param = &ctl.parameters[i];
             if arg_t != &param.ty {
-                diags.push(Diagnostic{
+                diags.push(Diagnostic {
                     level: Level::Error,
                     message: format!(
                         "wrong argument type for {} parameter {}\n    \
@@ -461,7 +456,9 @@ impl StructChecker {
                     diags.push(Diagnostic {
                         level: Level::Error,
                         message: format!(
-                            "Typename {} not found", typename.bright_blue()),
+                            "Typename {} not found",
+                            typename.bright_blue()
+                        ),
                         token: m.token.clone(),
                     })
                 }
@@ -482,7 +479,9 @@ impl HeaderChecker {
                     diags.push(Diagnostic {
                         level: Level::Error,
                         message: format!(
-                            "Typename {} not found", typename.bright_blue()),
+                            "Typename {} not found",
+                            typename.bright_blue()
+                        ),
                         token: m.token.clone(),
                     })
                 }
@@ -505,8 +504,8 @@ fn check_name(
                 level: Level::Error,
                 message: match parent {
                     Some(p) => format!(
-                        "{} does not have member {}", 
-                        p.bright_blue(), 
+                        "{} does not have member {}",
+                        p.bright_blue(),
                         name.bright_blue(),
                     ),
                     None => format!("'{}' is undefined", name),

--- a/p4/src/error.rs
+++ b/p4/src/error.rs
@@ -22,10 +22,19 @@ impl fmt::Display for SemanticError {
         let loc = format!("[{}:{}]", self.at.line + 1, self.at.col + 1)
             .as_str()
             .bright_red();
+        let parts: Vec<&str> = self.message.split_inclusive('\n').collect();
+        let msg = parts[0];
+        let extra = if parts.len() > 1 {
+            parts[1..].join("")
+        } else {
+            "\n".to_string()
+        };
         writeln!(
             f,
-            "{}\n{} {}\n",
-            self.message.bright_white(),
+            "{}: {}{}\n{} {}\n",
+            "error".red(),
+            msg.bright_white().bold(),
+            extra,
             loc,
             *self.at.file,
         )?;

--- a/p4/src/error.rs
+++ b/p4/src/error.rs
@@ -27,12 +27,12 @@ impl fmt::Display for SemanticError {
         let extra = if parts.len() > 1 {
             parts[1..].join("")
         } else {
-            "\n".to_string()
+            "".to_string()
         };
         writeln!(
             f,
             "{}: {}{}\n{} {}\n",
-            "error".red(),
+            "error".bright_red(),
             msg.bright_white().bold(),
             extra,
             loc,

--- a/p4/src/hlir.rs
+++ b/p4/src/hlir.rs
@@ -66,6 +66,9 @@ impl<'a> HlirGenerator<'a> {
             for (lval, _match_kind) in &t.key {
                 self.lvalue(lval, &mut local_names);
             }
+            for lval in &t.actions {
+                self.lvalue(lval, &mut local_names);
+            }
         }
         self.statement_block(&c.apply, &mut names);
     }
@@ -246,6 +249,14 @@ impl<'a> HlirGenerator<'a> {
                 self.diags.push(Diagnostic {
                     level: Level::Error,
                     message: "cannot index a state".into(),
+                    token: lval.token.clone(),
+                });
+                None
+            }
+            Type::Action=> {
+                self.diags.push(Diagnostic {
+                    level: Level::Error,
+                    message: "cannot index an action".into(),
                     token: lval.token.clone(),
                 });
                 None

--- a/p4/src/hlir.rs
+++ b/p4/src/hlir.rs
@@ -253,7 +253,7 @@ impl<'a> HlirGenerator<'a> {
                 });
                 None
             }
-            Type::Action=> {
+            Type::Action => {
                 self.diags.push(Diagnostic {
                     level: Level::Error,
                     message: "cannot index an action".into(),

--- a/p4/src/parser.rs
+++ b/p4/src/parser.rs
@@ -1594,7 +1594,7 @@ impl<'a, 'b> ExpressionParser<'a, 'b> {
                 }
                 // if it's not an index and it's not a call, it's an lvalue
                 else {
-                    self.parser.backlog.push(token.clone());
+                    self.parser.backlog.push(token);
                     Expression::new(this_token, ExpressionKind::Lvalue(lval))
                 }
             }

--- a/p4/src/parser.rs
+++ b/p4/src/parser.rs
@@ -1554,6 +1554,7 @@ impl<'a, 'b> ExpressionParser<'a, 'b> {
                 self.parser.backlog.push(token.clone());
                 let lval = self.parser.parse_lvalue()?;
 
+                let this_token = token.clone();
                 let token = self.parser.next_token()?;
 
                 // check for index
@@ -1594,7 +1595,7 @@ impl<'a, 'b> ExpressionParser<'a, 'b> {
                 // if it's not an index and it's not a call, it's an lvalue
                 else {
                     self.parser.backlog.push(token.clone());
-                    Expression::new(token, ExpressionKind::Lvalue(lval))
+                    Expression::new(this_token, ExpressionKind::Lvalue(lval))
                 }
             }
             lexer::Kind::CurlyOpen => {

--- a/p4/src/util.rs
+++ b/p4/src/util.rs
@@ -24,6 +24,7 @@ pub fn resolve_lvalue(
         Type::Void => root.clone(),
         Type::List(_) => root.clone(),
         Type::State => root.clone(),
+        Type::Action => root.clone(),
         Type::UserDefined(name) => {
             if lval.degree() == 1 {
                 root.clone()

--- a/test/src/p4/headers.p4
+++ b/test/src/p4/headers.p4
@@ -12,6 +12,12 @@ header ethernet_h {
     bit<16> ether_type;
 }
 
+header vlan_h {
+    bit<3> pcp;
+    bit<1> dei;
+    bit<12> vid;
+}
+
 header ipv6_h {
     bit<4>      version;
     bit<8>      traffic_class;

--- a/test/src/softnpu.rs
+++ b/test/src/softnpu.rs
@@ -241,12 +241,14 @@ pub struct TxFrame<'a> {
     pub ethertype: u16,
     pub payload: &'a [u8],
     pub sc_egress: u16,
+    pub vid: Option<u16>,
 }
 
 pub struct RxFrame<'a> {
     pub src: [u8; 6],
     pub ethertype: u16,
     pub payload: &'a [u8],
+    pub vid: Option<u16>,
 }
 
 impl<'a> RxFrame<'a> {
@@ -255,6 +257,20 @@ impl<'a> RxFrame<'a> {
             src,
             ethertype,
             payload,
+            vid: None,
+        }
+    }
+    pub fn newv(
+        src: [u8; 6],
+        ethertype: u16,
+        payload: &'a [u8],
+        vid: u16,
+    ) -> Self {
+        Self {
+            src,
+            ethertype,
+            payload,
+            vid: Some(vid),
         }
     }
 }
@@ -266,6 +282,22 @@ impl<'a> TxFrame<'a> {
             ethertype,
             payload,
             sc_egress: 0,
+            vid: None,
+        }
+    }
+
+    pub fn newv(
+        dst: [u8; 6],
+        ethertype: u16,
+        payload: &'a [u8],
+        vid: u16,
+    ) -> Self {
+        Self {
+            dst,
+            ethertype,
+            payload,
+            sc_egress: 0,
+            vid: Some(vid),
         }
     }
 }
@@ -366,12 +398,34 @@ impl<const R: usize, const N: usize, const F: usize> OuterPhy<R, N, F> {
                 self.rx_p.write_at(fp, [0u8; 16].as_slice(), off);
                 off += 16;
             } else {
-                self.rx_p.write_at(
-                    fp,
-                    f.ethertype.to_be_bytes().as_slice(),
-                    off,
-                );
-                off += 2;
+                if let Some(vid) = f.vid {
+                    self.rx_p.write_at(
+                        fp,
+                        0x8100u16.to_be_bytes().as_slice(),
+                        off,
+                    );
+                    off += 2;
+                    self.rx_p.write_at(
+                        fp,
+                        vid.to_be_bytes().as_slice(),
+                        off,
+                    );
+                    off += 2;
+                    self.rx_p.write_at(
+                        fp,
+                        f.ethertype.to_be_bytes().as_slice(),
+                        off,
+                    );
+                    off += 2;
+                }
+                else {
+                    self.rx_p.write_at(
+                        fp,
+                        f.ethertype.to_be_bytes().as_slice(),
+                        off,
+                    );
+                    off += 2;
+                }
             }
             self.rx_p.write_at(fp, f.payload, off);
         }
@@ -385,11 +439,17 @@ impl<const R: usize, const N: usize, const F: usize> OuterPhy<R, N, F> {
         loop {
             for fp in self.tx_c.consumable() {
                 let b = self.tx_c.read(fp);
+                let et = u16::from_be_bytes([b[12], b[13]]);
+                let payload = if et == 0x8100 {
+                    b[18..].to_vec()
+                } else {
+                    b[14..].to_vec()
+                };
                 let frame = OwnedFrame::new(
                     b[0..6].try_into().unwrap(),
                     b[6..12].try_into().unwrap(),
-                    u16::from_be_bytes([b[12], b[13]]),
-                    b[14..].to_vec(),
+                    et,
+                    payload,
                 );
                 buf.push(frame);
             }

--- a/test/src/softnpu.rs
+++ b/test/src/softnpu.rs
@@ -397,36 +397,27 @@ impl<const R: usize, const N: usize, const F: usize> OuterPhy<R, N, F> {
                 // sc_payload
                 self.rx_p.write_at(fp, [0u8; 16].as_slice(), off);
                 off += 16;
+            } else if let Some(vid) = f.vid {
+                self.rx_p
+                    .write_at(fp, 0x8100u16.to_be_bytes().as_slice(), off);
+                off += 2;
+                self.rx_p.write_at(fp, vid.to_be_bytes().as_slice(), off);
+                off += 2;
+                self.rx_p.write_at(
+                    fp,
+                    f.ethertype.to_be_bytes().as_slice(),
+                    off,
+                );
+                off += 2;
             } else {
-                if let Some(vid) = f.vid {
-                    self.rx_p.write_at(
-                        fp,
-                        0x8100u16.to_be_bytes().as_slice(),
-                        off,
-                    );
-                    off += 2;
-                    self.rx_p.write_at(
-                        fp,
-                        vid.to_be_bytes().as_slice(),
-                        off,
-                    );
-                    off += 2;
-                    self.rx_p.write_at(
-                        fp,
-                        f.ethertype.to_be_bytes().as_slice(),
-                        off,
-                    );
-                    off += 2;
-                }
-                else {
-                    self.rx_p.write_at(
-                        fp,
-                        f.ethertype.to_be_bytes().as_slice(),
-                        off,
-                    );
-                    off += 2;
-                }
+                self.rx_p.write_at(
+                    fp,
+                    f.ethertype.to_be_bytes().as_slice(),
+                    off,
+                );
+                off += 2;
             }
+
             self.rx_p.write_at(fp, f.payload, off);
         }
         self.rx_p.produce(n)?;

--- a/x4c/src/bin/x4c.rs
+++ b/x4c/src/bin/x4c.rs
@@ -17,7 +17,6 @@ fn run() -> Result<()> {
     let filename = Arc::new(opts.filename.clone());
     let mut ast = AST::default();
     x4c::process_file(filename, &mut ast, &opts)?;
-    let (hlir, _) = p4::check::all(&ast);
 
     if opts.check {
         return Ok(());
@@ -25,7 +24,10 @@ fn run() -> Result<()> {
 
     match opts.target {
         x4c::Target::Rust => {
+            // NOTE: it's important to sanitize *before* generating hlir as the
+            // sanitization process can change lvalue names.
             p4_rust::sanitize(&mut ast);
+            let (hlir, _) = p4::check::all(&ast);
             p4_rust::emit(
                 &ast,
                 &hlir,


### PR DESCRIPTION
A number of improvements in the path to implementing a VLAN switch with `x4c`.

- Add AST visitor machinery.
- Improved name sanitization for Rust code generation.
- Control parameter type checking.
- Improved lvalue checking results in useful errors rather than compiler assert failures in codegen phase.
- Fix bit-to-byte conversion for non-byte-aligned keysets and action parameters.
- Support for Ethernet frames with VLAN tags in SoftNpu testing machinery.
- Add VLAN switch example to docs.