### PR TITLE
Ingress/Egress Split

### DIFF
--- a/book/code/src/bin/hello-world.p4
+++ b/book/code/src/bin/hello-world.p4
@@ -6,11 +6,13 @@ struct headers_t {
 
 struct ingress_metadata_t {
     bit<16> port;
+    bool drop;
 }
 
 struct egress_metadata_t {
     bit<16> port;
     bool drop;
+    bool broadcast;
 }
 
 header ethernet_h {
@@ -66,7 +68,16 @@ control ingress(
 
 }
 
+control egress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
+
+}
+
 SoftNPU(
     parse(),
-    ingress()
+    ingress(),
+    egress()
 ) main;

--- a/book/code/src/bin/hello-world.rs
+++ b/book/code/src/bin/hello-world.rs
@@ -8,7 +8,7 @@ p4_macro::use_p4!(
 );
 
 fn main() -> Result<(), anyhow::Error> {
-    let mut npu = SoftNpu::new(2, main_pipeline::new(), false);
+    let mut npu = SoftNpu::new(2, main_pipeline::new(2), false);
     let phy1 = npu.phy(0);
     let phy2 = npu.phy(1);
 

--- a/book/code/src/bin/softnpu.p4
+++ b/book/code/src/bin/softnpu.p4
@@ -2,6 +2,7 @@ struct ingress_metadata_t {
     bit<16> port;
     bool nat;
     bit<16> nat_id;
+    bool drop;
 }
 
 struct egress_metadata_t {
@@ -9,6 +10,7 @@ struct egress_metadata_t {
     bit<128> nexthop_v6;
     bit<32> nexthop_v4;
     bool drop;
+    bool broadcast;
 }
 
 extern Checksum {

--- a/book/code/src/bin/vlan-switch.p4
+++ b/book/code/src/bin/vlan-switch.p4
@@ -80,7 +80,7 @@ control ingress(
         bool vlan_ok = false;
         vlan.apply(ingress.port, vid, vlan_ok);
         if (vlan_ok == false) {
-            egress.drop = true;
+            ingress.drop = true;
             return;
         }
 
@@ -90,13 +90,22 @@ control ingress(
         // check vlan on egress
         vlan.apply(egress.port, vid, vlan_ok);
         if (vlan_ok == false) {
-            egress.drop = true;
+            ingress.drop = true;
             return;
         }
     }
 }
 
+control egress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
+
+}
+
 SoftNPU(
     parse(), 
-    ingress()
+    ingress(),
+    egress()
 ) main;

--- a/book/code/src/bin/vlan-switch.rs
+++ b/book/code/src/bin/vlan-switch.rs
@@ -8,7 +8,7 @@ p4_macro::use_p4!(
 );
 
 fn main() -> Result<(), anyhow::Error> {
-    let mut pipeline = main_pipeline::new();
+    let mut pipeline = main_pipeline::new(2);
 
     let m1 = [0x33, 0x33, 0x33, 0x33, 0x33, 0x33];
     let m2 = [0x44, 0x44, 0x44, 0x44, 0x44, 0x44];

--- a/book/code/src/bin/vlan-switch.rs
+++ b/book/code/src/bin/vlan-switch.rs
@@ -20,22 +20,22 @@ fn main() -> Result<(), anyhow::Error> {
 
 fn init_tables(pipeline: &mut main_pipeline, m1: [u8; 6], m2: [u8; 6]) {
     // add static forwarding entries
-    pipeline.add_fwd_fib_entry("forward", &m1, &0u16.to_be_bytes());
-    pipeline.add_fwd_fib_entry("forward", &m2, &1u16.to_be_bytes());
+    pipeline.add_ingress_fwd_fib_entry("forward", &m1, &0u16.to_be_bytes());
+    pipeline.add_ingress_fwd_fib_entry("forward", &m2, &1u16.to_be_bytes());
 
     // port 0 vlan 47
-    pipeline.add_vlan_port_vlan_entry(
+    pipeline.add_ingress_vlan_port_vlan_entry(
         "filter",
         0u16.to_be_bytes().as_ref(),
         47u16.to_be_bytes().as_ref(),
     );
 
     // sanity check the table
-    let x = pipeline.get_vlan_port_vlan_entries();
+    let x = pipeline.get_ingress_vlan_port_vlan_entries();
     println!("{:#?}", x);
 
     // port 1 vlan 47
-    pipeline.add_vlan_port_vlan_entry(
+    pipeline.add_ingress_vlan_port_vlan_entry(
         "filter",
         1u16.to_be_bytes().as_ref(),
         47u16.to_be_bytes().as_ref(),

--- a/book/text/src/01-02-hello_world.md
+++ b/book/text/src/01-02-hello_world.md
@@ -289,10 +289,13 @@ struct headers_t {
 
 struct ingress_metadata_t {
     bit<16> port;
+    bool drop;
 }
 
 struct egress_metadata_t {
     bit<16> port;
+    bool drop;
+    bool broadcast;
 }
 
 header ethernet_h {
@@ -349,9 +352,20 @@ control ingress(
 
 }
 
+// We do not use an egress controller in this example, but one is required for
+// SoftNPU so just use an empty controller here.
+control egress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
+
+}
+
 SoftNPU(
     parse(),
-    ingress()
+    ingress(),
+    egress(),
 ) main;
 ```
 

--- a/book/text/src/01-03-compile_and_run.md
+++ b/book/text/src/01-03-compile_and_run.md
@@ -20,7 +20,7 @@ use tests::{expect_frames};
 p4_macro::use_p4!(p4 = "book/code/src/bin/hello-world.p4", pipeline_name = "hello");
 
 fn main() -> Result<(), anyhow::Error> {
-    let pipeline = main_pipeline::new();
+    let pipeline = main_pipeline::new(2);
     let mut npu = SoftNpu::new(2, pipeline, false);
     let phy1 = npu.phy(0);
     let phy2 = npu.phy(1);
@@ -61,7 +61,7 @@ The main artifact this produces is a Rust `struct` called `main_pipeline` which 
 in the code that comes next.
 
 ```rust
-let pipeline = main_pipeline::new();
+let pipeline = main_pipeline::new(2);
 let mut npu = SoftNpu::new(2, pipeline, false);
 let phy1 = npu.phy(0);
 let phy2 = npu.phy(1);

--- a/book/text/src/02-01-vlan-switch.md
+++ b/book/text/src/02-01-vlan-switch.md
@@ -325,22 +325,22 @@ Let's jump into the control plane code.
 ```rust
 fn init_tables(pipeline: &mut main_pipeline, m1: [u8;6], m2: [u8;6]) {
     // add static forwarding entries
-    pipeline.add_fwd_fib_entry("forward", &m1, &0u16.to_be_bytes());
-    pipeline.add_fwd_fib_entry("forward", &m2, &1u16.to_be_bytes());
+    pipeline.add_ingress_fwd_fib_entry("forward", &m1, &0u16.to_be_bytes());
+    pipeline.add_ingress_fwd_fib_entry("forward", &m2, &1u16.to_be_bytes());
 
     // port 0 vlan 47
-    pipeline.add_vlan_port_vlan_entry(
+    pipeline.add_ingress_vlan_port_vlan_entry(
         "filter",
         0u16.to_be_bytes().as_ref(),
         47u16.to_be_bytes().as_ref(),
     );
 
     // sanity check the table
-    let x = pipeline.get_vlan_port_vlan_entries();
+    let x = pipeline.get_ingress_vlan_port_vlan_entries();
     println!("{:#?}", x);
 
     // port 1 vlan 47
-    pipeline.add_vlan_port_vlan_entry(
+    pipeline.add_ingress_vlan_port_vlan_entry(
         "filter",
         1u16.to_be_bytes().as_ref(),
         47u16.to_be_bytes().as_ref(),

--- a/book/text/src/02-01-vlan-switch.md
+++ b/book/text/src/02-01-vlan-switch.md
@@ -298,7 +298,7 @@ p4_macro::use_p4!(
 );
 
 fn main() -> Result<(), anyhow::Error> {
-    let mut pipeline = main_pipeline::new();
+    let mut pipeline = main_pipeline::new(2);
 
     let m1 = [0x33, 0x33, 0x33, 0x33, 0x33, 0x33];
     let m2 = [0x44, 0x44, 0x44, 0x44, 0x44, 0x44];

--- a/codegen/rust/src/control.rs
+++ b/codegen/rust/src/control.rs
@@ -35,14 +35,20 @@ impl<'a> ControlGenerator<'a> {
             self.generate_control(control);
         }
 
-        let ingress = match self.ast.get_control("ingress") {
-            Some(i) => i,
-            None => return,
+        if let Some(ingress) = self.ast.get_control("ingress") {
+            self.generate_top_level_control(ingress);
         };
-        let tables = ingress.tables(self.ast);
+
+        if let Some(egress) = self.ast.get_control("egress") {
+            self.generate_top_level_control(egress);
+        };
+    }
+
+    fn generate_top_level_control(&mut self, control: &Control) {
+        let tables = control.tables(self.ast);
         for (cs, t) in tables {
-            let qtn = qualified_table_function_name(&cs, t);
-            let qtfn = qualified_table_function_name(&cs, t);
+            let qtn = qualified_table_function_name(Some(control), &cs, t);
+            let qtfn = qualified_table_function_name(Some(control), &cs, t);
             let control = cs.last().unwrap().1;
             let (_, mut param_types) = self.control_parameters(control);
             for var in &control.variables {
@@ -86,7 +92,7 @@ impl<'a> ControlGenerator<'a> {
         let tables = control.tables(self.ast);
         for (cs, table) in tables {
             let c = cs.last().unwrap().1;
-            let qtn = qualified_table_function_name(&cs, table);
+            let qtn = qualified_table_function_name(None, &cs, table);
             let (_, mut param_types) = self.control_parameters(c);
             for var in &c.variables {
                 if let Type::UserDefined(typename) = &var.ty {

--- a/codegen/rust/src/expression.rs
+++ b/codegen/rust/src/expression.rs
@@ -40,7 +40,7 @@ impl<'a> ExpressionGenerator<'a> {
                             p4rs::bitmath::add(#lhs_tks.clone(), #rhs_tks.clone())
                         });
                     }
-                    BinOp::Eq => {
+                    BinOp::Eq | BinOp::NotEq => {
                         let lhs_tks_ = match &lhs.as_ref().kind {
                             ExpressionKind::Lvalue(lval) => {
                                 let name_info = self
@@ -105,10 +105,6 @@ impl<'a> ExpressionGenerator<'a> {
                 ts
             }
             ExpressionKind::Slice(begin, end) => {
-                /*
-                let lhs = self.generate_expression(begin.as_ref());
-                let rhs = self.generate_expression(end.as_ref());
-                */
                 let l = match &begin.kind {
                     ExpressionKind::IntegerLit(v) => *v as usize,
                     _ => panic!("slice ranges can only be integer literals"),

--- a/codegen/rust/src/lib.rs
+++ b/codegen/rust/src/lib.rs
@@ -186,10 +186,14 @@ fn dtrace_probes() -> TokenStream {
             fn parser_transition(_: &str) {}
             fn parser_dropped() {}
             fn control_apply(_: &str) {}
-            fn control_dropped(_: &str) {}
-            fn control_accepted(_: &str) {}
             fn control_table_hit(_: &str) {}
             fn control_table_miss(_: &str) {}
+            fn ingress_dropped(_: &str) {}
+            fn ingress_accepted(_: &str) {}
+            fn egress_dropped(_: &str) {}
+            fn egress_accepted(_: &str) {}
+            fn egress_table_hit(_: &str) {}
+            fn egress_table_miss(_: &str) {}
             fn action(_: &str) {}
         }
     }

--- a/codegen/rust/src/lib.rs
+++ b/codegen/rust/src/lib.rs
@@ -221,6 +221,9 @@ fn rust_type(ty: &Type) -> TokenStream {
         Type::ExternFunction => {
             todo!("rust type for extern function");
         }
+        Type::HeaderMethod => {
+            todo!("rust type for header method");
+        }
         Type::Table => {
             todo!("rust type for table");
         }
@@ -271,6 +274,9 @@ fn type_size(ty: &Type, ast: &AST) -> usize {
         }
         Type::ExternFunction => {
             todo!("type size for extern function");
+        }
+        Type::HeaderMethod => {
+            todo!("type size for header method");
         }
         Type::Table => {
             todo!("type size for table");

--- a/codegen/rust/src/lib.rs
+++ b/codegen/rust/src/lib.rs
@@ -379,17 +379,29 @@ fn is_rust_reference(lval: &Lvalue, names: &HashMap<String, NameInfo>) -> bool {
 }
 
 fn qualified_table_name(
+    control: Option<&Control>,
     chain: &Vec<(String, &Control)>,
     table: &Table,
 ) -> String {
-    table_qname(chain, table, '.')
+    match control {
+        Some(control) => {
+            format!("{}.{}", control.name, table_qname(chain, table, '.'))
+        }
+        _ => table_qname(chain, table, '.'),
+    }
 }
 
 fn qualified_table_function_name(
+    control: Option<&Control>,
     chain: &Vec<(String, &Control)>,
     table: &Table,
 ) -> String {
-    table_qname(chain, table, '_')
+    match control {
+        Some(control) => {
+            format!("{}_{}", control.name, table_qname(chain, table, '_'))
+        }
+        _ => table_qname(chain, table, '_'),
+    }
 }
 
 fn table_qname(

--- a/codegen/rust/src/p4struct.rs
+++ b/codegen/rust/src/p4struct.rs
@@ -106,7 +106,7 @@ impl<'a> StructGenerator<'a> {
         };
         if !valid_member_size.is_empty() {
             structure.extend(quote! {
-                impl p4rs::Headers for #name {
+                impl #name {
                     fn valid_header_size(&self) -> usize {
                         let mut x: usize = 0;
                         #(#valid_member_size)*
@@ -128,7 +128,7 @@ impl<'a> StructGenerator<'a> {
             })
         } else {
             structure.extend(quote! {
-                impl p4rs::Headers for #name {
+                impl #name {
                     fn valid_header_size(&self) -> usize { 0 }
 
                     fn to_bitvec(&self) -> BitVec<u8, Msb0> {

--- a/codegen/rust/src/p4struct.rs
+++ b/codegen/rust/src/p4struct.rs
@@ -106,14 +106,14 @@ impl<'a> StructGenerator<'a> {
         };
         if !valid_member_size.is_empty() {
             structure.extend(quote! {
-                impl #name {
-                    pub fn valid_header_size(&self) -> usize {
+                impl p4rs::Headers for #name {
+                    fn valid_header_size(&self) -> usize {
                         let mut x: usize = 0;
                         #(#valid_member_size)*
                         x
                     }
 
-                    pub fn to_bitvec(&self) -> BitVec<u8, Msb0> {
+                    fn to_bitvec(&self) -> BitVec<u8, Msb0> {
                         let mut x =
                             bitvec![u8, Msb0; 0; self.valid_header_size()];
                         let mut off = 0;
@@ -121,21 +121,21 @@ impl<'a> StructGenerator<'a> {
                         x
                     }
 
-                    pub fn dump(&self) -> String {
+                    fn dump(&self) -> String {
                         #dump
                     }
                 }
             })
         } else {
             structure.extend(quote! {
-                impl #name {
-                    pub fn valid_header_size(&self) -> usize { 0 }
+                impl p4rs::Headers for #name {
+                    fn valid_header_size(&self) -> usize { 0 }
 
-                    pub fn to_bitvec(&self) -> BitVec<u8, Msb0> {
+                    fn to_bitvec(&self) -> BitVec<u8, Msb0> {
                         bitvec![u8, Msb0; 0; 0]
                     }
 
-                    pub fn dump(&self) -> String {
+                    fn dump(&self) -> String {
                         std::string::String::new()
                     }
                 }

--- a/codegen/rust/src/p4struct.rs
+++ b/codegen/rust/src/p4struct.rs
@@ -99,7 +99,7 @@ impl<'a> StructGenerator<'a> {
         let name = format_ident!("{}", s.name);
 
         let mut structure = quote! {
-            #[derive(Debug, Default)]
+            #[derive(Debug, Default, Clone)]
             pub struct #name {
                 #(#members),*
             }

--- a/codegen/rust/src/pipeline.rs
+++ b/codegen/rust/src/pipeline.rs
@@ -529,6 +529,9 @@ impl<'a> PipelineGenerator<'a> {
                     Type::ExternFunction => {
                         todo!();
                     }
+                    Type::HeaderMethod => {
+                        todo!();
+                    }
                     Type::Table => {
                         todo!();
                     }

--- a/codegen/rust/src/pipeline.rs
+++ b/codegen/rust/src/pipeline.rs
@@ -111,12 +111,6 @@ impl<'a> PipelineGenerator<'a> {
         let (egress_member, egress_initializer) =
             self.control_entrypoint("egress", egress);
 
-        // XXX
-        //let control_ = ingress; //hack in something
-        //let pipeline_impl_process_packet =
-        //    self.pipeline_impl_process_packet(parser, control_);
-        // XXX
-
         let pipeline_impl_parse = self.pipeline_impl_parse(parser);
         let pipeline_impl_ingress = self.pipeline_impl_ingress(parser, ingress);
         let pipeline_impl_egress = self.pipeline_impl_egress(parser, egress);
@@ -182,7 +176,6 @@ impl<'a> PipelineGenerator<'a> {
                 type Header = #parsed_type;
                 type I = ingress_metadata_t;
                 type E = egress_metadata_t;
-                //XXX #pipeline_impl_process_packet
                 #pipeline_impl_parse
                 #pipeline_impl_ingress
                 #pipeline_impl_egress
@@ -332,117 +325,6 @@ impl<'a> PipelineGenerator<'a> {
                 };
 
                 Some(out)
-            }
-        }
-    }
-
-    //XXX break up
-    fn _pipeline_impl_process_packet(
-        &mut self,
-        _parser: &Parser,
-        _control: &Control,
-    ) -> TokenStream {
-        /*
-        let parsed_type = rust_type(&parser.parameters[1].ty);
-
-        // determine table arguments
-        let tables = control.tables(self.ast);
-        let mut tbl_args = Vec::new();
-        for (cs, t) in tables {
-            let qtfn = qualified_table_function_name(&cs, t);
-            let name = format_ident!("{}", qtfn);
-            tbl_args.push(quote! {
-                &self.#name
-            });
-        }
-        */
-
-        quote! {
-            fn process_packet<'a>(
-                &mut self,
-                port: u16,
-                pkt: &mut packet_in<'a>,
-            ) -> Option<(packet_out<'a>, u16)> {
-
-                panic!("depracated!");
-
-                /*
-                //
-                // 1. Instantiate the parser out type
-                //
-
-                let mut parsed = #parsed_type::default();
-
-                //
-                // 2. Instantiate ingress/egress metadata
-                //
-                let mut ingress_metadata = ingress_metadata_t{
-                    port: {
-                        let mut x = bitvec![mut u8, Msb0; 0; 16];
-                        x.store_le(port);
-                        x
-                    },
-                    ..Default::default()
-                };
-                let mut egress_metadata = egress_metadata_t::default();
-
-                //
-                // 3. run the parser block
-                //
-                let accept = (self.parse)(pkt, &mut parsed, &mut ingress_metadata);
-                if !accept {
-                    // drop the packet
-                    softnpu_provider::parser_dropped!(||());
-                    return None
-                }
-                let dump = parsed.dump();
-                softnpu_provider::parser_accepted!(||(&dump));
-
-                //
-                // 4. Calculate parsed header size
-                //
-
-                let parsed_size = parsed.valid_header_size() >> 3;
-
-                //
-                // 5. Run the control block
-                //
-
-                (self.control)(
-                    &mut parsed,
-                    &mut ingress_metadata,
-                    &mut egress_metadata,
-                    #(#tbl_args),*
-                );
-
-                //
-                // 6. Determine egress port
-                //
-
-                let port: u16 = if egress_metadata.port.is_empty()
-                    || egress_metadata.drop {
-                    softnpu_provider::control_dropped!(||(&dump));
-                    return None;
-                } else {
-                    egress_metadata.port.load_le()
-                };
-
-                let dump = parsed.dump();
-                softnpu_provider::control_accepted!(||(&dump));
-
-                //
-                // 7. Create the packet output.
-
-                let bv = parsed.to_bitvec();
-                let buf = bv.as_raw_slice();
-                let out = packet_out{
-                    header_data: buf.to_owned(),
-                    payload_data: &pkt.data[parsed_size..],
-                };
-
-                Some((out, port))
-                */
-
             }
         }
     }

--- a/codegen/rust/src/statement.rs
+++ b/codegen/rust/src/statement.rs
@@ -444,7 +444,8 @@ impl<'a> StatementGenerator<'a> {
 
             let tables = control_instance.tables(self.ast);
             for (cs, table) in tables {
-                let qtn = crate::qualified_table_function_name(&cs, table);
+                let qtn =
+                    crate::qualified_table_function_name(None, &cs, table);
                 let name = format_ident!("{}_{}", c.lval.root(), qtn);
                 args.push(quote! { #name });
             }

--- a/codegen/rust/src/statement.rs
+++ b/codegen/rust/src/statement.rs
@@ -381,18 +381,8 @@ impl<'a> StatementGenerator<'a> {
             let mut locals = Vec::new();
             let mut args = Vec::new();
             for (i, a) in c.args.iter().enumerate() {
-                let mut arg_xpr = eg.generate_expression(a.as_ref());
+                let arg_xpr = eg.generate_expression(a.as_ref());
                 let et = self.hlir.expression_types.get(a.as_ref()).unwrap();
-                // if the argument is an lvalue and a rust type that gets passed
-                // by reference, take a ref
-                if let ExpressionKind::Lvalue(_) = a.as_ref().kind {
-                    match et {
-                        Type::Bit(_) | Type::Varbit(_) | Type::Int(_) => {
-                            arg_xpr = quote! { &#arg_xpr };
-                        }
-                        _ => {}
-                    }
-                }
                 let local_name = format_ident!("arg{}", i);
                 if let ExpressionKind::BitLit(_, _) = a.as_ref().kind {
                     locals.push(quote! {
@@ -414,6 +404,9 @@ impl<'a> StatementGenerator<'a> {
                                     )
                                     });
                                 match name_info.decl {
+                                    // if this is a control parameter, it should
+                                    // already have the correct reference
+                                    // annotations
                                     DeclarationInfo::Parameter(_) => {
                                         args.push(arg_xpr);
                                     }
@@ -434,6 +427,14 @@ impl<'a> StatementGenerator<'a> {
                         ExpressionKind::BitLit(_, _) => {
                             args.push(quote! { &#local_name })
                         }
+                        // if the argument is an lvalue and a rust type that
+                        // gets passed by reference, take a ref
+                        ExpressionKind::Lvalue(_) => match et {
+                            Type::Bit(_) | Type::Varbit(_) | Type::Int(_) => {
+                                args.push(quote! { &#arg_xpr });
+                            }
+                            _ => {}
+                        },
                         _ => {
                             args.push(arg_xpr);
                         }

--- a/lang/p4rs/src/lib.rs
+++ b/lang/p4rs/src/lib.rs
@@ -64,18 +64,6 @@
 //!         out.extend_from_slice(out_pkt.payload_data);
 //!         self.send_packet(egress_md.port(), &out);
 //!
-//!         /*
-//!         let mut input = packet_in::new(pkt);
-//!         if let Some((mut out_pkt, out_port)) =
-//!             self.pipe.process_packet(port, &mut input) {
-//!
-//!             let mut out = out_pkt.header_data.clone();
-//!             out.extend_from_slice(out_pkt.payload_data);
-//!
-//!             self.send_packet(out_port, &out);
-//!
-//!         }
-//!         */
 //!     }
 //!
 //!     /// Add a routing table entry. Packets for the provided destination will
@@ -215,15 +203,6 @@ pub trait Pipeline: Send {
     type Header: Headers;
     type I: IngressMetadata;
     type E: EgressMetadata;
-    /// Process a packet for the specified port optionally producing an output
-    /// packet and output port number.
-    //XXX
-    //fn process_packet<'a>(
-    //    &mut self,
-    //    port: u16,
-    //    pkt: &mut packet_in<'a>,
-    //) -> Option<(packet_out<'a>, u16)>;
-    //XXX
 
     fn parse<'a>(
         &mut self,

--- a/p4/examples/bad/checker/parser-non-struct-output.p4
+++ b/p4/examples/bad/checker/parser-non-struct-output.p4
@@ -1,8 +1,0 @@
-parser bad_parser(
-    packet_in pkt,
-    out int the_badness,
-) {
-    state start {
-        transition accept;
-    }
-}

--- a/p4/examples/bad/parser/badness-included.p4
+++ b/p4/examples/bad/parser/badness-included.p4
@@ -1,2 +1,2 @@
-#include <p4/examples/bad/checker/undefined_type_ref_parser_arg.p4>
-#include <p4/examples/bad/checker/parser-no-start-state.p4>
+#include <../checker/undefined_type_ref_parser_arg.p4>
+#include <../checker/parser-no-start-state.p4>

--- a/p4/examples/codegen/router.p4
+++ b/p4/examples/codegen/router.p4
@@ -17,6 +17,7 @@ struct ingress_metadata_t {
     bit<16> port;
     bool nat;
     bit<16> nat_id;
+    bool drop;
 }
 
 struct egress_metadata_t {
@@ -24,11 +25,13 @@ struct egress_metadata_t {
     bit<128> nexthop_v6;
     bit<32> nexthop_v4;
     bool drop;
+    bool broadcast;
 }
 
 SoftNPU(
     parse(),
-    ingress()
+    ingress(),
+    egress()
 ) main;
 
 struct headers_t {
@@ -104,5 +107,13 @@ control ingress(
     apply {
         router.apply();
     }
+
+}
+
+control egress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
 
 }

--- a/p4/examples/codegen/softnpu.p4
+++ b/p4/examples/codegen/softnpu.p4
@@ -2,12 +2,14 @@ struct ingress_metadata_t {
     bit<16> port;
     bool nat;
     bit<16> nat_id;
+    bool drop;
 }
 
 struct egress_metadata_t {
     bit<16> port;
     bit<128> nexthop;
     bool drop;
+    bool broadcast;
 }
 
 extern Checksum {

--- a/p4/examples/softnpu.p4
+++ b/p4/examples/softnpu.p4
@@ -1,3 +1,4 @@
+//FIXME there are a number of compilation issues with this file
 typedef bit<4> PortId;
 
 const PortId REAL_PORT_COUNT = 4w4;
@@ -24,7 +25,14 @@ control NpuIngress<H>(
     inout egress_metadata_t egress_meta,
 );
 
+control NpuEgress<H>(
+    inout H hdr,
+    inout ingress_metadata_t ingress_meta,
+    inout egress_metadata_t egress_meta,
+);
+
 package SoftNPU<H>(
     NpuParser<H> p,
     NpuIngress<H> ingress,
+    NpuEgress<H> ingress,
 );

--- a/p4/src/ast.rs
+++ b/p4/src/ast.rs
@@ -212,6 +212,7 @@ pub enum Type {
     List(Vec<Box<Type>>),
     State,
     Action,
+    HeaderMethod,
 }
 
 impl Type {
@@ -248,6 +249,7 @@ impl fmt::Display for Type {
             Type::Void => write!(f, "void"),
             Type::State => write!(f, "state"),
             Type::Action => write!(f, "action"),
+            Type::HeaderMethod => write!(f, "header method"),
             Type::List(elems) => {
                 write!(f, "list<")?;
                 for e in elems {
@@ -463,6 +465,27 @@ impl Header {
     }
     pub fn names(&self) -> HashMap<String, NameInfo> {
         let mut names = HashMap::new();
+        names.insert(
+            "setValid".into(),
+            NameInfo {
+                ty: Type::HeaderMethod,
+                decl: DeclarationInfo::Method,
+            },
+        );
+        names.insert(
+            "setInvalid".into(),
+            NameInfo {
+                ty: Type::HeaderMethod,
+                decl: DeclarationInfo::Method,
+            },
+        );
+        names.insert(
+            "isValid".into(),
+            NameInfo {
+                ty: Type::HeaderMethod,
+                decl: DeclarationInfo::Method,
+            },
+        );
         for p in &self.members {
             names.insert(
                 p.name.clone(),

--- a/p4/src/ast.rs
+++ b/p4/src/ast.rs
@@ -422,7 +422,7 @@ pub enum ExpressionKind {
     List(Vec<Box<Expression>>),
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BinOp {
     Add,
     Subtract,

--- a/p4/src/check.rs
+++ b/p4/src/check.rs
@@ -791,6 +791,15 @@ fn check_lvalue(
                 });
             }
         }
+        Type::HeaderMethod => {
+            if parts.len() > 1 {
+                diags.push(Diagnostic {
+                    level: Level::Error,
+                    message: "header methods do not have members".into(),
+                    token: lval.token.clone(),
+                });
+            }
+        }
         Type::Table => {
             if parts.len() > 1 && parts.last() != Some(&"apply") {
                 diags.push(Diagnostic {

--- a/p4/src/check.rs
+++ b/p4/src/check.rs
@@ -196,6 +196,7 @@ impl ControlChecker {
         hlir: &Hlir,
         diags: &mut Diagnostics,
     ) {
+        diags.extend(&check_statement_block_lvalues(&c.apply, ast, &c.names()));
         for s in &c.apply.statements {
             if let Statement::Call(call) = s {
                 Self::check_apply_call(c, call, ast, hlir, diags);
@@ -736,7 +737,7 @@ fn check_lvalue(
                     message: format!(
                         "type {} does not have a member {}",
                         format!("bit<{}>", size).bright_blue(),
-                        parts[1],
+                        parts[1].bright_blue(),
                     ),
                     token: lval.token.clone(),
                 });
@@ -749,7 +750,7 @@ fn check_lvalue(
                     message: format!(
                         "type {} does not have a member {}",
                         format!("varbit<{}>", size).bright_blue(),
-                        parts[1]
+                        parts[1].bright_blue(),
                     ),
                     token: lval.token.clone(),
                 });
@@ -762,7 +763,7 @@ fn check_lvalue(
                     message: format!(
                         "type int<{}> does not have a member {}",
                         format!("int<{}>", size).bright_blue(),
-                        parts[1]
+                        parts[1].bright_blue(),
                     ),
                     token: lval.token.clone(),
                 });
@@ -775,7 +776,7 @@ fn check_lvalue(
                     message: format!(
                         "type {} does not have a member {}",
                         "string".bright_blue(),
-                        parts[1]
+                        parts[1].bright_blue(),
                     ),
                     token: lval.token.clone(),
                 });
@@ -791,13 +792,13 @@ fn check_lvalue(
             }
         }
         Type::Table => {
-            if parts.len() > 1 {
+            if parts.len() > 1 && parts.last() != Some(&"apply") {
                 diags.push(Diagnostic {
                     level: Level::Error,
                     message: format!(
                         "type {} does not have a member {}",
                         "table".bright_blue(),
-                        parts[1]
+                        parts[1].bright_blue(),
                     ),
                     token: lval.token.clone(),
                 });
@@ -810,7 +811,7 @@ fn check_lvalue(
                     message: format!(
                         "type {} does not have a member {}",
                         "void".bright_blue(),
-                        parts[1]
+                        parts[1].bright_blue(),
                     ),
                     token: lval.token.clone(),
                 });
@@ -823,7 +824,7 @@ fn check_lvalue(
                     message: format!(
                         "type {} does not have a member {}",
                         "list".bright_blue(),
-                        parts[1]
+                        parts[1].bright_blue(),
                     ),
                     token: lval.token.clone(),
                 });
@@ -885,6 +886,18 @@ fn check_lvalue(
                         Some(&parent.name),
                     );
                     diags.extend(&sub_diags);
+                }
+            } else if let Some(_control) = ast.get_control(&name) {
+                if parts.len() > 1 && parts.last() != Some(&"apply") {
+                    diags.push(Diagnostic {
+                        level: Level::Error,
+                        message: format!(
+                            "Control {} has no member {}",
+                            name.bright_blue(),
+                            parts.last().unwrap().bright_blue(),
+                        ),
+                        token: lval.token.clone(),
+                    });
                 }
             } else {
                 diags.push(Diagnostic {

--- a/p4/src/hlir.rs
+++ b/p4/src/hlir.rs
@@ -357,6 +357,14 @@ impl<'a> HlirGenerator<'a> {
                 });
                 None
             }
+            Type::HeaderMethod => {
+                self.diags.push(Diagnostic {
+                    level: Level::Error,
+                    message: "cannot index a header method".into(),
+                    token: lval.token.clone(),
+                });
+                None
+            }
             Type::Table => {
                 self.diags.push(Diagnostic {
                     level: Level::Error,

--- a/p4/src/hlir.rs
+++ b/p4/src/hlir.rs
@@ -446,12 +446,12 @@ impl<'a> HlirGenerator<'a> {
                     .insert(lval.clone(), name_info.clone());
                 Some(name_info.ty)
             }
-            Err(_e) => {
+            Err(e) => {
                 self.diags.push(Diagnostic {
                     level: Level::Error,
                     message: format!(
-                        "could not resolve lvalue: {}",
-                        lval.name,
+                        "could not resolve lvalue: {}\n    {}",
+                        lval.name, e,
                     ),
                     token: lval.token.clone(),
                 });

--- a/p4/src/util.rs
+++ b/p4/src/util.rs
@@ -20,6 +20,7 @@ pub fn resolve_lvalue(
         Type::Int(_) => root.clone(),
         Type::String => root.clone(),
         Type::ExternFunction => root.clone(),
+        Type::HeaderMethod => root.clone(),
         Type::Table => root.clone(),
         Type::Void => root.clone(),
         Type::List(_) => root.clone(),

--- a/p4/src/util.rs
+++ b/p4/src/util.rs
@@ -10,7 +10,7 @@ pub fn resolve_lvalue(
 ) -> Result<NameInfo, String> {
     let root = match names.get(lval.root()) {
         Some(name_info) => name_info,
-        None => return Err(format!("codegen: unresolved lval {:#?}", lval)),
+        None => return Err(format!("{} not found", lval.root())),
     };
     let result = match &root.ty {
         Type::Bool => root.clone(),
@@ -36,7 +36,7 @@ pub fn resolve_lvalue(
                 resolve_lvalue(&lval.pop_left(), ast, &parent.names())?
             } else {
                 return Err(format!(
-                    "codegen: User defined name '{}' does not exist",
+                    "User defined name '{}' does not exist",
                     name
                 ));
             }

--- a/test/src/basic_router.rs
+++ b/test/src/basic_router.rs
@@ -24,7 +24,7 @@ p4_macro::use_p4!(
 
 #[test]
 fn basic_router2() -> Result<(), anyhow::Error> {
-    let mut npu = SoftNpu::new(2, main_pipeline::new(), false);
+    let mut npu = SoftNpu::new(2, main_pipeline::new(2), false);
     let phy1 = npu.phy(0);
     let phy2 = npu.phy(1);
 

--- a/test/src/disag_router.rs
+++ b/test/src/disag_router.rs
@@ -29,7 +29,7 @@ p4_macro::use_p4!(p4 = "test/src/p4/router.p4", pipeline_name = "disag",);
 
 #[test]
 fn disag_router() -> Result<(), anyhow::Error> {
-    let mut npu = SoftNpu::new(4, main_pipeline::new(), true);
+    let mut npu = SoftNpu::new(4, main_pipeline::new(4), true);
     let cpu = npu.phy(0);
     let phy1 = npu.phy(1);
     let phy2 = npu.phy(2);

--- a/test/src/dynamic_router.rs
+++ b/test/src/dynamic_router.rs
@@ -34,7 +34,7 @@ p4_macro::use_p4!(
 
 #[test]
 fn dynamic_router2() -> Result<(), anyhow::Error> {
-    let mut pipeline = main_pipeline::new();
+    let mut pipeline = main_pipeline::new(4);
 
     //
     // add table entries

--- a/test/src/dynamic_router.rs
+++ b/test/src/dynamic_router.rs
@@ -44,19 +44,31 @@ fn dynamic_router2() -> Result<(), anyhow::Error> {
     let mut buf = prefix.octets().to_vec();
     buf.push(24); // prefix length
 
-    pipeline.add_router_router_entry("forward", &buf, &1u16.to_be_bytes());
+    pipeline.add_ingress_router_router_entry(
+        "forward",
+        &buf,
+        &1u16.to_be_bytes(),
+    );
 
     let prefix: Ipv6Addr = "fd00:2000::".parse().unwrap();
     let mut buf = prefix.octets().to_vec();
     buf.push(24); // prefix length
 
-    pipeline.add_router_router_entry("forward", &buf, &2u16.to_be_bytes());
+    pipeline.add_ingress_router_router_entry(
+        "forward",
+        &buf,
+        &2u16.to_be_bytes(),
+    );
 
     let prefix: Ipv6Addr = "fd00:3000::".parse().unwrap();
     let mut buf = prefix.octets().to_vec();
     buf.push(24); // prefix length
 
-    pipeline.add_router_router_entry("forward", &buf, &3u16.to_be_bytes());
+    pipeline.add_ingress_router_router_entry(
+        "forward",
+        &buf,
+        &3u16.to_be_bytes(),
+    );
 
     //
     // run program

--- a/test/src/hub.rs
+++ b/test/src/hub.rs
@@ -20,7 +20,7 @@ p4_macro::use_p4!(p4 = "test/src/p4/hub.p4", pipeline_name = "hub2");
 ///
 #[test]
 fn hub2() -> Result<(), anyhow::Error> {
-    let mut npu = SoftNpu::new(2, main_pipeline::new(), false);
+    let mut npu = SoftNpu::new(2, main_pipeline::new(2), false);
     let phy1 = npu.phy(0);
     let phy2 = npu.phy(1);
 

--- a/test/src/hub.rs
+++ b/test/src/hub.rs
@@ -13,16 +13,24 @@ p4_macro::use_p4!(p4 = "test/src/p4/hub.p4", pipeline_name = "hub2");
 ///                               ▼
 /// *=======*                *==========*                *=======*
 /// |       | --- ( rx ) --> |          | <-- ( rx ) --- |       |
-/// | phy 1 |                | pipeline |                | phy 2 |
+/// | phy 1 |                | pipeline |                | phy 3 |
 /// |       | <-- ( tx ) --- |          | --- ( tx ) --> |       |
 /// *=======*                *==========*                *=======*
-///
+///                           tx |  ▲   
+///                              |  |   
+///                              ▼  | rx
+///                           *========*
+///                           |        |
+///                           |        |
+///                           |  phy2  |
+///                           *========*
 ///
 #[test]
 fn hub2() -> Result<(), anyhow::Error> {
-    let mut npu = SoftNpu::new(2, main_pipeline::new(2), false);
+    let mut npu = SoftNpu::new(3, main_pipeline::new(3), false);
     let phy1 = npu.phy(0);
     let phy2 = npu.phy(1);
+    let phy3 = npu.phy(2);
 
     npu.run();
 
@@ -31,12 +39,15 @@ fn hub2() -> Result<(), anyhow::Error> {
 
     phy1.send(&[TxFrame::new(phy2.mac, et, msg.0)])?;
     expect_frames!(phy2, &[RxFrame::new(phy1.mac, et, msg.0)]);
+    expect_frames!(phy3, &[RxFrame::new(phy1.mac, et, msg.0)]);
 
     phy2.send(&[TxFrame::new(phy1.mac, et, msg.1)])?;
     expect_frames!(phy1, &[RxFrame::new(phy2.mac, et, msg.1)]);
+    expect_frames!(phy3, &[RxFrame::new(phy2.mac, et, msg.1)]);
 
     phy1.send(&[TxFrame::new(phy2.mac, et, msg.2)])?;
     expect_frames!(phy2, &[RxFrame::new(phy1.mac, et, msg.2)]);
+    expect_frames!(phy3, &[RxFrame::new(phy1.mac, et, msg.2)]);
 
     phy2.send(&[TxFrame::new(phy1.mac, et, msg.3)])?;
     phy2.send(&[TxFrame::new(phy1.mac, et, msg.4)])?;
@@ -49,12 +60,23 @@ fn hub2() -> Result<(), anyhow::Error> {
             RxFrame::new(phy2.mac, et, msg.5),
         ]
     );
+    expect_frames!(
+        phy3,
+        &[
+            RxFrame::new(phy2.mac, et, msg.3),
+            RxFrame::new(phy2.mac, et, msg.4),
+            RxFrame::new(phy2.mac, et, msg.5),
+        ]
+    );
 
     assert_eq!(phy1.tx_count(), 2usize);
     assert_eq!(phy1.rx_count(), 4usize);
 
     assert_eq!(phy2.tx_count(), 4usize);
     assert_eq!(phy2.rx_count(), 2usize);
+
+    assert_eq!(phy3.tx_count(), 0usize);
+    assert_eq!(phy3.rx_count(), 6usize);
 
     Ok(())
 }

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -14,6 +14,8 @@ mod headers;
 mod hub;
 #[cfg(test)]
 mod mac_rewrite;
+#[cfg(test)]
+mod table_in_egress_and_ingress;
 
 pub mod data;
 pub mod packet;

--- a/test/src/mac_rewrite.rs
+++ b/test/src/mac_rewrite.rs
@@ -41,17 +41,17 @@ fn mac_rewrite2() -> Result<(), anyhow::Error> {
     let addr_e: Ipv6Addr = "fe80::aae1:deff:fe01:701e".parse().unwrap();
 
     pipeline.add_local_local_entry(
-        "local".into(),
+        "set_local".into(),
         addr_c.octets().as_ref(),
         &Vec::new(),
     );
     pipeline.add_local_local_entry(
-        "local".into(),
+        "set_local".into(),
         addr_d.octets().as_ref(),
         &Vec::new(),
     );
     pipeline.add_local_local_entry(
-        "local".into(),
+        "set_local".into(),
         addr_e.octets().as_ref(),
         &Vec::new(),
     );

--- a/test/src/mac_rewrite.rs
+++ b/test/src/mac_rewrite.rs
@@ -40,17 +40,17 @@ fn mac_rewrite2() -> Result<(), anyhow::Error> {
     let addr_d: Ipv6Addr = "fe80::aae1:deff:fe01:701d".parse().unwrap();
     let addr_e: Ipv6Addr = "fe80::aae1:deff:fe01:701e".parse().unwrap();
 
-    pipeline.add_local_local_entry(
+    pipeline.add_ingress_local_local_entry(
         "set_local".into(),
         addr_c.octets().as_ref(),
         &Vec::new(),
     );
-    pipeline.add_local_local_entry(
+    pipeline.add_ingress_local_local_entry(
         "set_local".into(),
         addr_d.octets().as_ref(),
         &Vec::new(),
     );
-    pipeline.add_local_local_entry(
+    pipeline.add_ingress_local_local_entry(
         "set_local".into(),
         addr_e.octets().as_ref(),
         &Vec::new(),
@@ -58,19 +58,19 @@ fn mac_rewrite2() -> Result<(), anyhow::Error> {
 
     // resolver table entries
 
-    pipeline.add_router_resolver_resolver_entry(
+    pipeline.add_ingress_router_resolver_resolver_entry(
         "rewrite_dst".into(),
         addr_c.octets().as_ref(),
         &[0x44, 0x44, 0x44, 0x44, 0x44, 0x44],
     );
 
-    pipeline.add_router_resolver_resolver_entry(
+    pipeline.add_ingress_router_resolver_resolver_entry(
         "rewrite_dst".into(),
         addr_d.octets().as_ref(),
         &[0x33, 0x33, 0x33, 0x33, 0x33, 0x33],
     );
 
-    pipeline.add_router_resolver_resolver_entry(
+    pipeline.add_ingress_router_resolver_resolver_entry(
         "rewrite_dst".into(),
         addr_e.octets().as_ref(),
         &[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
@@ -83,21 +83,21 @@ fn mac_rewrite2() -> Result<(), anyhow::Error> {
     key.push(24); // prefix length
     let mut args = 1u16.to_be_bytes().to_vec();
     args.extend_from_slice(&addr_c.octets());
-    pipeline.add_router_router_entry("forward", &key, &args);
+    pipeline.add_ingress_router_router_entry("forward", &key, &args);
 
     let prefix: Ipv6Addr = "fd00:2000::".parse().unwrap();
     let mut key = prefix.octets().to_vec();
     key.push(24); // prefix length
     let mut args = 2u16.to_be_bytes().to_vec();
     args.extend_from_slice(&addr_d.octets());
-    pipeline.add_router_router_entry("forward", &key, &args);
+    pipeline.add_ingress_router_router_entry("forward", &key, &args);
 
     let prefix: Ipv6Addr = "fd00:3000::".parse().unwrap();
     let mut key = prefix.octets().to_vec();
     key.push(24); // prefix length
     let mut args = 3u16.to_be_bytes().to_vec();
     args.extend_from_slice(&addr_e.octets());
-    pipeline.add_router_router_entry("forward", &key, &args);
+    pipeline.add_ingress_router_router_entry("forward", &key, &args);
 
     //
     // run program

--- a/test/src/mac_rewrite.rs
+++ b/test/src/mac_rewrite.rs
@@ -31,7 +31,7 @@ p4_macro::use_p4!(
 
 #[test]
 fn mac_rewrite2() -> Result<(), anyhow::Error> {
-    let mut pipeline = main_pipeline::new();
+    let mut pipeline = main_pipeline::new(4);
 
     //
     // add table entries

--- a/test/src/p4/controller_multiple_instantiation.p4
+++ b/test/src/p4/controller_multiple_instantiation.p4
@@ -3,7 +3,8 @@
 
 SoftNPU(
     parse(),
-    ingress()
+    ingress(),
+    egress()
 ) main;
 
 struct headers_t { }
@@ -60,4 +61,12 @@ control ingress(
         taco.apply();
         pizza.apply();
     }
+}
+
+control egress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
+
 }

--- a/test/src/p4/dynamic_router.p4
+++ b/test/src/p4/dynamic_router.p4
@@ -4,7 +4,8 @@
 
 SoftNPU(
     parse(),
-    ingress()
+    ingress(),
+    egress()
 ) main;
 
 struct headers_t {
@@ -187,4 +188,12 @@ control ingress(
             router.apply(hdr, ingress, egress);
         }
     }
+}
+
+control egress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
+
 }

--- a/test/src/p4/dynamic_router_noaddr.p4
+++ b/test/src/p4/dynamic_router_noaddr.p4
@@ -4,7 +4,8 @@
 
 SoftNPU(
     parse(),
-    ingress()
+    ingress(),
+    egress()
 ) main;
 
 struct headers_t {
@@ -177,4 +178,12 @@ control ingress(
             router.apply(hdr, ingress, egress);
         }
     }
+}
+
+control egress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
+
 }

--- a/test/src/p4/dynamic_router_noaddr_nbr.p4
+++ b/test/src/p4/dynamic_router_noaddr_nbr.p4
@@ -4,7 +4,8 @@
 
 SoftNPU(
     parse(),
-    ingress()
+    ingress(),
+    egress()
 ) main;
 
 struct headers_t {
@@ -53,7 +54,7 @@ control local(
         is_local = false;
     }
 
-    action local() {
+    action set_local() {
         is_local = true;
     }
 
@@ -62,7 +63,7 @@ control local(
             hdr.ipv6.dst: exact;
         }
         actions = {
-            local;
+            set_local;
             nonlocal;
         }
         default_action = nonlocal;
@@ -215,4 +216,12 @@ control ingress(
             router.apply(hdr, ingress, egress);
         }
     }
+}
+
+control egress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
+
 }

--- a/test/src/p4/hub.p4
+++ b/test/src/p4/hub.p4
@@ -42,6 +42,7 @@ control ingress(
 
     action forward(bit<16> port) {
         egress.port = port;
+        egress.broadcast = true;
     }
 
     table tbl {

--- a/test/src/p4/hub.p4
+++ b/test/src/p4/hub.p4
@@ -3,7 +3,8 @@
 
 SoftNPU(
     parse(),
-    ingress()
+    ingress(),
+    egress()
 ) main;
 
 struct headers_t {
@@ -61,5 +62,13 @@ control ingress(
     apply {
         tbl.apply();
     }
+
+}
+
+control egress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
 
 }

--- a/test/src/p4/router.p4
+++ b/test/src/p4/router.p4
@@ -4,7 +4,8 @@
 
 SoftNPU(
     parse(),
-    ingress()
+    ingress(),
+    egress()
 ) main;
 
 struct headers_t {
@@ -205,4 +206,12 @@ control ingress(
             router.apply(hdr, ingress, egress);
         }
     }
+}
+
+control egress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
+
 }

--- a/test/src/p4/sidecar-lite.p4
+++ b/test/src/p4/sidecar-lite.p4
@@ -4,7 +4,8 @@
 
 SoftNPU(
     parse(),
-    ingress()
+    ingress(),
+    egress()
 ) main;
 
 struct headers_t {
@@ -680,4 +681,12 @@ control ingress(
 
         mac.apply(hdr, egress);
     }
+}
+
+control egress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
+
 }

--- a/test/src/p4/softnpu.p4
+++ b/test/src/p4/softnpu.p4
@@ -1,7 +1,7 @@
 struct ingress_metadata_t {
     bit<16> port;
-    bool nat;
-    bit<16> nat_id;
+    bool nat; // XXX this should be a program specific thing
+    bit<16> nat_id; // XXX this should be a program specific thing
     bool drop;
 }
 

--- a/test/src/p4/softnpu.p4
+++ b/test/src/p4/softnpu.p4
@@ -2,6 +2,7 @@ struct ingress_metadata_t {
     bit<16> port;
     bool nat;
     bit<16> nat_id;
+    bool drop;
 }
 
 struct egress_metadata_t {
@@ -9,6 +10,7 @@ struct egress_metadata_t {
     bit<128> nexthop_v6;
     bit<32> nexthop_v4;
     bool drop;
+    bool broadcast;
 }
 
 extern Checksum {

--- a/test/src/p4/table_in_egress_and_ingress.p4
+++ b/test/src/p4/table_in_egress_and_ingress.p4
@@ -1,0 +1,62 @@
+#include <core.p4>
+#include <softnpu.p4>
+#include <headers.p4>
+
+SoftNPU(
+    parse(),
+    ingress(),
+    egress()
+) main;
+
+struct headers_t {
+    ethernet_h eth;
+}
+
+parser parse(
+    packet_in pkt,
+    out headers_t headers,
+    inout ingress_metadata_t ingress,
+){
+    state start {
+        transition accept;
+    }
+}
+
+control foo(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
+
+    action drop() { }
+    action forward(bit<16> port) { egress.port = port; }
+    table tbl {
+        key = { ingress.port: exact; }
+        actions = { drop; forward; }
+        default_action = drop;
+    }
+
+}
+
+control ingress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
+    foo() foo;
+    apply {
+        foo.apply(hdr, ingress, egress);
+    }
+}
+
+control egress(
+    inout headers_t hdr,
+    inout ingress_metadata_t ingress,
+    inout egress_metadata_t egress,
+) {
+    foo() foo;
+    apply {
+        foo.apply(hdr, ingress, egress);
+    }
+}
+

--- a/test/src/softnpu.rs
+++ b/test/src/softnpu.rs
@@ -19,6 +19,8 @@ pub fn do_expect_frames(
     loop {
         let fs = phy.recv();
         frames.extend_from_slice(&fs);
+        // TODO this is not a great interface, if frames.len() > n, we should do
+        // something besides hang forever.
         if frames.len() == n {
             break;
         }
@@ -176,6 +178,9 @@ impl<P: p4rs::Pipeline + 'static> SoftNpu<P> {
                 ig.rx_counter.fetch_add(frames_in, Ordering::Relaxed);
 
                 for (j, n) in egress_count.iter().enumerate() {
+                    if *n == 0 {
+                        continue;
+                    }
                     let phy = &inner_phys[j];
                     phy.tx_p.produce(*n).unwrap();
                     phy.tx_counter.fetch_add(*n, Ordering::Relaxed);

--- a/test/src/softnpu.rs
+++ b/test/src/softnpu.rs
@@ -136,44 +136,6 @@ impl<P: p4rs::Pipeline + 'static> SoftNpu<P> {
 
                     let mut pkt = packet_in::new(content);
 
-                    /*
-                    match pipeline.process_packet(i as u16, &mut pkt) {
-                        Some((out_pkt, port)) => {
-                            let port = port as usize;
-
-                            //
-                            // get frame for packet
-                            //
-
-                            let phy = &inner_phys[port];
-                            let eg = &phy.tx_p;
-                            let mut fps = eg.reserve(1).unwrap();
-                            let fp = fps.next().unwrap();
-
-                            //
-                            // emit headers
-                            //
-
-                            eg.write_at(fp, out_pkt.header_data.as_slice(), 0);
-
-                            //
-                            // emit payload
-                            //
-
-                            eg.write_at(
-                                fp,
-                                out_pkt.payload_data,
-                                out_pkt.header_data.len(),
-                            );
-
-                            egress_count[port] += 1;
-                        }
-                        None => {
-                            println!("drop");
-                        }
-                    }
-                    */
-
                     let (mut hdr, mut ingress_md, mut egress_md) =
                         match pipeline.parse(i as u16, &mut pkt) {
                             Some(hdr) => hdr,

--- a/test/src/softnpu.rs
+++ b/test/src/softnpu.rs
@@ -75,10 +75,10 @@ const FBUF: usize = 4096;
 const MTU: usize = 1500;
 
 pub struct SoftNpu<P: p4rs::Pipeline> {
+    pub pipeline: Option<P>,
     inner_phys: Option<Vec<InnerPhy<RING, FBUF, MTU>>>,
     outer_phys: Vec<Arc<OuterPhy<RING, FBUF, MTU>>>,
     _fb: Arc<FrameBuffer<FBUF, MTU>>,
-    pipeline: Option<P>,
 }
 
 impl<P: p4rs::Pipeline + 'static> SoftNpu<P> {
@@ -458,6 +458,10 @@ impl<const R: usize, const N: usize, const F: usize> OuterPhy<R, N, F> {
         self.rx_counter.fetch_add(buf.len(), Ordering::Relaxed);
 
         buf
+    }
+
+    pub fn recv_buffer_len(&self) -> usize {
+        self.tx_c.consumable().count()
     }
 
     pub fn tx_count(&self) -> usize {

--- a/test/src/softnpu.rs
+++ b/test/src/softnpu.rs
@@ -80,6 +80,11 @@ pub struct SoftNpu<P: p4rs::Pipeline> {
 }
 
 impl<P: p4rs::Pipeline + 'static> SoftNpu<P> {
+    /// Create a new SoftNpu ASIC emulator. The `radix` indicates the number of
+    /// ports. The `pipeline` is the `x4c` compiled program that the ASIC will
+    /// run. When `cpu_port` is set to true, sidecar data in `TxFrame` elements
+    /// will be added to packets sent through port 0 (as a sidecar header) on
+    /// the way to the ASIC.
     pub fn new(radix: usize, pipeline: P, cpu_port: bool) -> Self {
         let fb = Arc::new(FrameBuffer::<FBUF, MTU>::new());
         let mut inner_phys = Vec::new();

--- a/test/src/table_in_egress_and_ingress.rs
+++ b/test/src/table_in_egress_and_ingress.rs
@@ -1,0 +1,11 @@
+p4_macro::use_p4!(
+    p4 = "test/src/p4/table_in_egress_and_ingress.p4",
+    pipeline_name = "table_in_ingresss_and_egress",
+);
+
+// This test is just to make sure the above code compiles
+
+#[test]
+fn table_in_egress_and_ingress() {
+    println!("table in ingress and egress compiles");
+}


### PR DESCRIPTION
## Primary Change

This PR splits the single SoftNpu package control block parameter into 2 distinct top-level ingress and egress controls. This is to move closer to typical real-world ASIC package structures and to support simple broadcast mechanics between the ingress and egress control blocks.

SoftNpu P4 programs can now set `egress_metadata_t.broadcast` to true if they want packets leaving the `ingress` top-level control block to be replicated to all other ports on the ASIC. The `egress` control block is then run over each replicated packet.

This is a breaking change since the package P4 signature for `SoftNpu` is changing. Current SoftNpu P4 programs can update by simply creating an empty control block as an egress controller and supplying that block to the SoftNpu package constructor. This should result in a P4 program with the same behavior as the previous single-control-block SoftNpu package definition.

## Also Included

Several front-end compiler enhancements are included in this PR.

- All values in control apply blocks are now checked. Previously this was just select function cal parameters.
- Intrinsic header methods (`setValid`, `setInvalid`, `isValid`) are now a part of the header name context for lvalue checking.
- Identifier errors are much more informative, telling the user what sort of associated semantic element was expecting an identifier. For example, "table name expected" instead of "identifier expected".