### PR TITLE
Fix buffer resize bug

### DIFF
--- a/codegen/rust/src/control.rs
+++ b/codegen/rust/src/control.rs
@@ -104,7 +104,7 @@ impl<'a> ControlGenerator<'a> {
                     }
                 }
             }
-            let n = table.key.len() as usize;
+            let n = table.key.len();
             let table_type = quote! {
                 p4rs::table::Table::<
                     #n,
@@ -311,7 +311,7 @@ impl<'a> ControlGenerator<'a> {
         }
 
         let table_name = format_ident!("{}_table", table.name);
-        let n = table.key.len() as usize;
+        let n = table.key.len();
         let table_type = quote! {
             p4rs::table::Table::<
                 #n,
@@ -417,14 +417,14 @@ impl<'a> ControlGenerator<'a> {
                     ExpressionKind::BitLit(width, v) => {
                         match &action.parameters[i].ty {
                             Type::Bit(n) => {
-                                let n = *n as usize;
+                                let n = *n;
                                 if n != *width as usize {
                                     panic!(
                                         "{:?} not compatible with {:?}",
                                         expr.kind, action.parameters[i],
                                     );
                                 }
-                                let size = n as usize;
+                                let size = n;
                                 action_fn_args.push(quote! {{
                                     let mut x = bitvec![mut u8, Msb0; 0; #size];
                                     x.store_le(#v);

--- a/codegen/rust/src/pipeline.rs
+++ b/codegen/rust/src/pipeline.rs
@@ -362,7 +362,7 @@ impl<'a> PipelineGenerator<'a> {
                 }
             }
 
-            let n = table.key.len() as usize;
+            let n = table.key.len();
             let table_type = quote! {
                 p4rs::table::Table::<
                     #n,

--- a/lang/p4rs/src/table.rs
+++ b/lang/p4rs/src/table.rs
@@ -77,7 +77,6 @@ impl Key {
                     IpAddr::V6(a) => a.octets().into(),
                 };
                 v.push(p.len);
-                v.resize(v.len(), 0);
                 v
             }
         }

--- a/lang/p4rs/src/table.rs
+++ b/lang/p4rs/src/table.rs
@@ -32,20 +32,43 @@ impl Default for Key {
 
 impl Key {
     pub fn to_bytes(&self) -> Vec<u8> {
-        let (mut buf, width) = match self {
-            Key::Exact(x) => (x.value.to_bytes_be(), x.width),
+        match self {
+            Key::Exact(x) => {
+                let mut buf = x.value.to_bytes_be();
+
+                // A value serialized from a BigUint may be less than the width of a
+                // field. For example a 16-bit field with with a value of 47 will come
+                // back in 8 bits from BigUint serialization.
+                buf.resize(x.width, 0);
+                buf
+            }
             Key::Range(a, z) => {
-                let mut v = a.value.to_bytes_be();
-                v.extend_from_slice(&z.value.to_bytes_be());
-                (v, a.width)
+                let mut buf_a = a.value.to_bytes_be();
+                let mut buf_z = z.value.to_bytes_be();
+
+                buf_a.resize(a.width, 0);
+                buf_z.resize(z.width, 0);
+                buf_a.extend_from_slice(&buf_z);
+                buf_a
             }
             Key::Ternary(t) => match t {
-                Ternary::DontCare => (Vec::new(), 0),
-                Ternary::Value(v) => (v.value.to_bytes_be(), v.width),
+                Ternary::DontCare => {
+                    let mut buf = Vec::new();
+                    buf.clear();
+                    buf
+                }
+                Ternary::Value(v) => {
+                    let mut buf = v.value.to_bytes_be();
+                    buf.resize(v.width, 0);
+                    buf
+                }
                 Ternary::Masked(v, m, w) => {
-                    let mut x = v.to_bytes_be();
-                    x.extend_from_slice(&m.to_bytes_be());
-                    (x, *w)
+                    let mut buf_a = v.to_bytes_be();
+                    let mut buf_b = m.to_bytes_be();
+                    buf_a.resize(*w, 0);
+                    buf_b.resize(*w, 0);
+                    buf_a.extend_from_slice(&buf_b);
+                    buf_a
                 }
             },
             Key::Lpm(p) => {
@@ -54,15 +77,10 @@ impl Key {
                     IpAddr::V6(a) => a.octets().into(),
                 };
                 v.push(p.len);
-                let w = v.len();
-                (v, w)
+                v.resize(v.len(), 0);
+                v
             }
-        };
-        // A value serialized from a BigUint may be less than the width of a
-        // field. For example a 16-bit field with with a value of 47 will come
-        // back in 8 bits from BigUint serialization.
-        buf.resize(width, 0);
-        buf
+        }
     }
 }
 

--- a/test/src/dload.rs
+++ b/test/src/dload.rs
@@ -28,7 +28,7 @@ fn dynamic_load() -> Result<(), anyhow::Error> {
     // see .cargo/config.toml
     let ws = std::env::var("CARGO_WORKSPACE_DIR").unwrap();
     let path = format!("{}/target/debug/libsidecar_lite.so", ws);
-    let lib = match unsafe { libloading::Library::new(&path) } {
+    let lib = match unsafe { libloading::Library::new(path) } {
         Ok(l) => l,
         Err(e) => {
             panic!("failed to load p4 program: {}", e);

--- a/test/src/mac_rewrite.rs
+++ b/test/src/mac_rewrite.rs
@@ -41,17 +41,17 @@ fn mac_rewrite2() -> Result<(), anyhow::Error> {
     let addr_e: Ipv6Addr = "fe80::aae1:deff:fe01:701e".parse().unwrap();
 
     pipeline.add_ingress_local_local_entry(
-        "set_local".into(),
+        "set_local",
         addr_c.octets().as_ref(),
         &Vec::new(),
     );
     pipeline.add_ingress_local_local_entry(
-        "set_local".into(),
+        "set_local",
         addr_d.octets().as_ref(),
         &Vec::new(),
     );
     pipeline.add_ingress_local_local_entry(
-        "set_local".into(),
+        "set_local",
         addr_e.octets().as_ref(),
         &Vec::new(),
     );
@@ -59,19 +59,19 @@ fn mac_rewrite2() -> Result<(), anyhow::Error> {
     // resolver table entries
 
     pipeline.add_ingress_router_resolver_resolver_entry(
-        "rewrite_dst".into(),
+        "rewrite_dst",
         addr_c.octets().as_ref(),
         &[0x44, 0x44, 0x44, 0x44, 0x44, 0x44],
     );
 
     pipeline.add_ingress_router_resolver_resolver_entry(
-        "rewrite_dst".into(),
+        "rewrite_dst",
         addr_d.octets().as_ref(),
         &[0x33, 0x33, 0x33, 0x33, 0x33, 0x33],
     );
 
     pipeline.add_ingress_router_resolver_resolver_entry(
-        "rewrite_dst".into(),
+        "rewrite_dst",
         addr_e.octets().as_ref(),
         &[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
     );

--- a/test/src/softnpu.rs
+++ b/test/src/softnpu.rs
@@ -385,12 +385,12 @@ impl<const R: usize, const N: usize, const F: usize> OuterPhy<R, N, F> {
                 self.rx_p.write_at(fp, &[0u8], off);
                 off += 1;
                 // sc_ingress
-                let ingress = f.sc_egress as u16;
+                let ingress = f.sc_egress;
                 self.rx_p
                     .write_at(fp, ingress.to_be_bytes().as_slice(), off);
                 off += 2;
                 // sc_egress
-                let egress = f.sc_egress as u16;
+                let egress = f.sc_egress;
                 self.rx_p.write_at(fp, egress.to_be_bytes().as_slice(), off);
                 off += 2;
                 // sc_ether_type


### PR DESCRIPTION
We were accidentally truncating the Vec<u8> values returned by `Key#to_bytes()`. This patch should make sure that we are resizing according to each individual key before joining them together into a single Vec<u8>.