### PR TITLE
endian specific adders

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "build-and-test"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-latest"
 #: rust_toolchain = "stable"
 #: output_rules = [
 #:   "/work/debug/*",

--- a/codegen/rust/src/expression.rs
+++ b/codegen/rust/src/expression.rs
@@ -37,7 +37,7 @@ impl<'a> ExpressionGenerator<'a> {
                 match op {
                     BinOp::Add => {
                         ts.extend(quote!{
-                            p4rs::bitmath::add(#lhs_tks.clone(), #rhs_tks.clone())
+                            p4rs::bitmath::add_le(#lhs_tks.clone(), #rhs_tks.clone())
                         });
                     }
                     BinOp::Eq | BinOp::NotEq => {

--- a/codegen/rust/src/header.rs
+++ b/codegen/rust/src/header.rs
@@ -87,7 +87,7 @@ impl<'a> HeaderGenerator<'a> {
 
             });
             checksum_statements.push(quote! {
-                csum = p4rs::bitmath::add(csum.clone(), self.#name.csum())
+                csum = p4rs::bitmath::add_le(csum.clone(), self.#name.csum())
             });
             dump_statements.push(quote! {
                 #name_s.cyan(),

--- a/dtrace/softnpu-inout.d
+++ b/dtrace/softnpu-inout.d
@@ -1,0 +1,7 @@
+::parser_accepted {
+    printf("%s", copyinstr(arg0));
+}
+
+::ingress_accepted {
+    printf("%s", copyinstr(arg0));
+}

--- a/lang/p4rs/src/bitmath.rs
+++ b/lang/p4rs/src/bitmath.rs
@@ -2,7 +2,7 @@
 
 use bitvec::prelude::*;
 
-pub fn add(a: BitVec<u8, Msb0>, b: BitVec<u8, Msb0>) -> BitVec<u8, Msb0> {
+pub fn add_be(a: BitVec<u8, Msb0>, b: BitVec<u8, Msb0>) -> BitVec<u8, Msb0> {
     if a.len() != b.len() {
         panic!("bitvec add size mismatch");
     }
@@ -15,6 +15,22 @@ pub fn add(a: BitVec<u8, Msb0>, b: BitVec<u8, Msb0>) -> BitVec<u8, Msb0> {
     let mut c = BitVec::new();
     c.resize(a.len(), false);
     c.store_be(z);
+    c
+}
+
+pub fn add_le(a: BitVec<u8, Msb0>, b: BitVec<u8, Msb0>) -> BitVec<u8, Msb0> {
+    if a.len() != b.len() {
+        panic!("bitvec add size mismatch");
+    }
+
+    // P4 spec says width limits are architecture defined, i here by define
+    // softnpu to have an architectural bit-type width limit of 128.
+    let x: u128 = a.load_le();
+    let y: u128 = b.load_le();
+    let z = x + y;
+    let mut c = BitVec::new();
+    c.resize(a.len(), false);
+    c.store_le(z);
     c
 }
 
@@ -63,7 +79,7 @@ mod tests {
 
         println!("{:?}", a);
         println!("{:?}", b);
-        let c = add(a, b);
+        let c = add_be(a, b);
         println!("{:?}", c);
 
         let cc: u128 = c.load_be();
@@ -82,9 +98,47 @@ mod tests {
         let mut d = bitvec![mut u8, Msb0; 0; 16];
         d.store_be(9876);
 
-        let e = add(a, add(b, add(c, d)));
+        let e = add_be(a, add_be(b, add_be(c, d)));
 
         let ee: u128 = e.load_be();
         assert_eq!(ee, 47u128 + 74u128 + 123u128 + 9876u128);
+    }
+
+    #[test]
+    fn bitmath_add_nest() {
+        use super::*;
+        let mut orig_l3_len = bitvec![mut u8, Msb0; 0; 16usize];
+        orig_l3_len.store_le(0xe9u128);
+        let x = add_le(
+            {
+                let mut x = bitvec![mut u8, Msb0; 0; 16usize];
+                x.store_le(14u128);
+                x
+            }
+            .clone(),
+            add_le(
+                orig_l3_len.clone(),
+                add_le(
+                    {
+                        let mut x = bitvec![mut u8, Msb0; 0; 16usize];
+                        x.store_le(8u128);
+                        x
+                    }
+                    .clone(),
+                    {
+                        let mut x = bitvec![mut u8, Msb0; 0; 16usize];
+                        x.store_le(8u128);
+                        x
+                    }
+                    .clone(),
+                )
+                .clone(),
+            )
+            .clone(),
+        )
+        .clone();
+
+        let y: u128 = x.load_le();
+        assert_eq!(y, 0xe9 + 14 + 8 + 8);
     }
 }

--- a/test/src/softnpu.rs
+++ b/test/src/softnpu.rs
@@ -369,7 +369,7 @@ impl<const R: usize, const N: usize, const F: usize> OuterPhy<R, N, F> {
         }
     }
 
-    pub fn send<'a>(&self, frames: &[TxFrame<'a>]) -> Result<(), xfr::Error> {
+    pub fn send(&self, frames: &[TxFrame<'_>]) -> Result<(), xfr::Error> {
         let n = frames.len();
         let fps = self.rx_p.reserve(n)?;
         for (i, fp) in fps.enumerate() {


### PR DESCRIPTION
Compiled `bit` types have a little-endian underlying representation. This is, however, an implementation detail. At one point, they had big endian representation. When the transition to little endian was made, some details were left behind in the adder functions. This resulted in garbage values from add ops.

This commit introduces endian-specific adders and moves compiled code to `add_le`.
