### PR TITLE
accept bitvec refs to for checksums, fix crash for no parser statements, update dtrace scripts, mixed width addition

### DIFF
--- a/dtrace/softnpu-stats.d
+++ b/dtrace/softnpu-stats.d
@@ -14,11 +14,11 @@
     @stats["control apply", copyinstr(arg0)]= count();
 }
 
-::control_dropped {
+::ingress_dropped {
     @stats["control", "drop"] = count();
 }
 
-::control_accepted {
+::ingress_accepted {
     @stats["control", "accept"] = count();
 }
 
@@ -30,7 +30,7 @@
     @stats["table miss", copyinstr(arg0)] = count();
 }
 
-tick-10sec
+tick-5sec
 {
     printa(@stats);
     printf("==========================================================================================================================\n");

--- a/lang/p4rs/src/bitmath.rs
+++ b/lang/p4rs/src/bitmath.rs
@@ -3,9 +3,7 @@
 use bitvec::prelude::*;
 
 pub fn add_be(a: BitVec<u8, Msb0>, b: BitVec<u8, Msb0>) -> BitVec<u8, Msb0> {
-    if a.len() != b.len() {
-        panic!("bitvec add size mismatch");
-    }
+    let len = usize::max(a.len(), b.len());
 
     // P4 spec says width limits are architecture defined, i here by define
     // softnpu to have an architectural bit-type width limit of 128.
@@ -13,15 +11,13 @@ pub fn add_be(a: BitVec<u8, Msb0>, b: BitVec<u8, Msb0>) -> BitVec<u8, Msb0> {
     let y: u128 = b.load_be();
     let z = x + y;
     let mut c = BitVec::new();
-    c.resize(a.len(), false);
+    c.resize(len, false);
     c.store_be(z);
     c
 }
 
 pub fn add_le(a: BitVec<u8, Msb0>, b: BitVec<u8, Msb0>) -> BitVec<u8, Msb0> {
-    if a.len() != b.len() {
-        panic!("bitvec add size mismatch");
-    }
+    let len = usize::max(a.len(), b.len());
 
     // P4 spec says width limits are architecture defined, i here by define
     // softnpu to have an architectural bit-type width limit of 128.
@@ -29,7 +25,7 @@ pub fn add_le(a: BitVec<u8, Msb0>, b: BitVec<u8, Msb0>) -> BitVec<u8, Msb0> {
     let y: u128 = b.load_le();
     let z = x + y;
     let mut c = BitVec::new();
-    c.resize(a.len(), false);
+    c.resize(len, false);
     c.store_le(z);
     c
 }
@@ -84,6 +80,23 @@ mod tests {
 
         let cc: u128 = c.load_be();
         assert_eq!(cc, 47u128 + 74u128);
+    }
+
+    #[test]
+    fn bitmath_add_mixed_size() {
+        use super::*;
+        let mut a = bitvec![mut u8, Msb0; 0; 8];
+        a.store_be(0xAB);
+        let mut b = bitvec![mut u8, Msb0; 0; 16];
+        b.store_be(0xCDE);
+
+        println!("{:?}", a);
+        println!("{:?}", b);
+        let c = add_be(a, b);
+        println!("{:?}", c);
+
+        let cc: u128 = c.load_be();
+        assert_eq!(cc, 0xABu128 + 0xCDEu128);
     }
 
     #[test]

--- a/lang/p4rs/src/checksum.rs
+++ b/lang/p4rs/src/checksum.rs
@@ -131,17 +131,27 @@ pub trait Checksum {
     fn csum(&self) -> BitVec<u8, Msb0>;
 }
 
+fn bvec_csum(bv: &BitVec<u8, Msb0>) -> BitVec<u8, Msb0> {
+    let x: u128 = bv.load();
+    let buf = x.to_be_bytes();
+    let mut c: u16 = 0;
+    for i in (0..16).step_by(2) {
+        c += u16::from_be_bytes([buf[i], buf[i + 1]])
+    }
+    let c = !c;
+    let mut result = bitvec![u8, Msb0; 0u8, 16];
+    result.store(c);
+    result
+}
+
 impl Checksum for BitVec<u8, Msb0> {
     fn csum(&self) -> BitVec<u8, Msb0> {
-        let x: u128 = self.load();
-        let buf = x.to_be_bytes();
-        let mut c: u16 = 0;
-        for i in (0..16).step_by(2) {
-            c += u16::from_be_bytes([buf[i], buf[i + 1]])
-        }
-        let c = !c;
-        let mut result = bitvec![u8, Msb0; 0u8, 16];
-        result.store(c);
-        result
+        bvec_csum(self)
+    }
+}
+
+impl Checksum for &BitVec<u8, Msb0> {
+    fn csum(&self) -> BitVec<u8, Msb0> {
+        bvec_csum(self)
     }
 }

--- a/p4/src/check.rs
+++ b/p4/src/check.rs
@@ -409,8 +409,8 @@ impl ParserChecker {
         //TODO the right thing to do here is to ensure all code paths end in a
         //     transition, for now just check that the last statement is a
         //     transition.
-        let last = &stmts[stmts.len() - 1];
-        if !matches!(last, Statement::Transition(_)) {
+        let last = stmts.last();
+        if !matches!(last, Some(Statement::Transition(_))) {
             diags.push(Diagnostic {
                 level: Level::Error,
                 message: "final parser state statement must be a transition"


### PR DESCRIPTION
- Fixes #35 