### PR TITLE
Add support for the % operator

### DIFF
--- a/codegen/rust/src/expression.rs
+++ b/codegen/rust/src/expression.rs
@@ -40,6 +40,11 @@ impl<'a> ExpressionGenerator<'a> {
                             p4rs::bitmath::add_le(#lhs_tks.clone(), #rhs_tks.clone())
                         });
                     }
+                    BinOp::Mod => {
+                        ts.extend(quote!{
+                            p4rs::bitmath::mod_le(#lhs_tks.clone(), #rhs_tks.clone())
+                        });
+                    }
                     BinOp::Eq | BinOp::NotEq => {
                         let lhs_tks_ = match &lhs.as_ref().kind {
                             ExpressionKind::Lvalue(lval) => {

--- a/codegen/rust/src/expression.rs
+++ b/codegen/rust/src/expression.rs
@@ -170,6 +170,7 @@ impl<'a> ExpressionGenerator<'a> {
         match op {
             BinOp::Add => quote! { + },
             BinOp::Subtract => quote! { - },
+            BinOp::Mod => quote! { % },
             BinOp::Geq => quote! { >= },
             BinOp::Gt => quote! { > },
             BinOp::Leq => quote! { <= },

--- a/codegen/rust/src/statement.rs
+++ b/codegen/rust/src/statement.rs
@@ -601,6 +601,9 @@ impl<'a> StatementGenerator<'a> {
             (Type::Int(_), Type::Bit(_)) => {
                 quote! { p4rs::int_to_bitvec }
             }
+            (Type::Bit(x), Type::Bit(16)) if *x <= 16 => {
+                quote! { p4rs::bitvec_to_bitvec16 }
+            }
             _ => todo!("type converter for {} to {}", from, to),
         }
     }

--- a/lang/p4rs/src/bitmath.rs
+++ b/lang/p4rs/src/bitmath.rs
@@ -62,6 +62,34 @@ pub fn add_generic(
     c
 }
 
+pub fn mod_be(a: BitVec<u8, Msb0>, b: BitVec<u8, Msb0>) -> BitVec<u8, Msb0> {
+    let len = usize::max(a.len(), b.len());
+
+    // P4 spec says width limits are architecture defined, i here by define
+    // softnpu to have an architectural bit-type width limit of 128.
+    let x: u128 = a.load_be();
+    let y: u128 = b.load_be();
+    let z = x % y;
+    let mut c = BitVec::new();
+    c.resize(len, false);
+    c.store_be(z);
+    c
+}
+
+pub fn mod_le(a: BitVec<u8, Msb0>, b: BitVec<u8, Msb0>) -> BitVec<u8, Msb0> {
+    let len = usize::max(a.len(), b.len());
+
+    // P4 spec says width limits are architecture defined, i here by define
+    // softnpu to have an architectural bit-type width limit of 128.
+    let x: u128 = a.load_le();
+    let y: u128 = b.load_le();
+    let z = x % y;
+    let mut c = BitVec::new();
+    c.resize(len, false);
+    c.store_le(z);
+    c
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -147,5 +175,22 @@ mod tests {
 
         let y: u128 = x.load_le();
         assert_eq!(y, 0xe9 + 14 + 8 + 8);
+    }
+
+    #[test]
+    fn bitmath_mod() {
+        use super::*;
+        let mut a = bitvec![mut u8, Msb0; 0; 16];
+        a.store_be(47);
+        let mut b = bitvec![mut u8, Msb0; 0; 16];
+        b.store_be(7);
+
+        println!("{:?}", a);
+        println!("{:?}", b);
+        let c = mod_be(a, b);
+        println!("{:?}", c);
+
+        let cc: u128 = c.load_be();
+        assert_eq!(cc, 47u128 % 7u128);
     }
 }

--- a/lang/p4rs/src/lib.rs
+++ b/lang/p4rs/src/lib.rs
@@ -262,6 +262,11 @@ pub fn int_to_bitvec(x: i128) -> BitVec<u8, Msb0> {
     bv
 }
 
+pub fn bitvec_to_bitvec16(mut x: BitVec<u8, Msb0>) -> BitVec<u8, Msb0> {
+    x.resize(16, false);
+    x
+}
+
 pub fn dump_bv(x: &BitVec<u8, Msb0>) -> String {
     if x.is_empty() {
         "∅".into()

--- a/p4/src/ast.rs
+++ b/p4/src/ast.rs
@@ -643,6 +643,7 @@ pub enum ExpressionKind {
 pub enum BinOp {
     Add,
     Subtract,
+    Mod,
     Geq,
     Gt,
     Leq,
@@ -660,6 +661,7 @@ impl BinOp {
         match self {
             BinOp::Add => "add",
             BinOp::Subtract => "subtract",
+            BinOp::Mod => "mod",
             BinOp::Geq | BinOp::Gt | BinOp::Leq | BinOp::Lt | BinOp::Eq => {
                 "compare"
             }

--- a/p4/src/lexer.rs
+++ b/p4/src/lexer.rs
@@ -81,6 +81,7 @@ pub enum Kind {
     Equals,
     Plus,
     Minus,
+    Mod,
     Dot,
     Mask,
     LogicalAnd,
@@ -208,6 +209,7 @@ impl fmt::Display for Kind {
             Kind::Equals => write!(f, "operator ="),
             Kind::Plus => write!(f, "operator +"),
             Kind::Minus => write!(f, "operator -"),
+            Kind::Mod => write!(f, "operator %"),
             Kind::Dot => write!(f, "operator ."),
             Kind::Mask => write!(f, "operator &&&"),
             Kind::LogicalAnd => write!(f, "operator &&"),
@@ -460,6 +462,10 @@ impl<'a> Lexer<'a> {
         }
 
         if let Some(t) = self.match_token("-", Kind::Minus) {
+            return Ok(t);
+        }
+
+        if let Some(t) = self.match_token("%", Kind::Mod) {
             return Ok(t);
         }
 

--- a/p4/src/parser.rs
+++ b/p4/src/parser.rs
@@ -443,6 +443,7 @@ impl<'a> Parser<'a> {
             lexer::Kind::DoubleEquals => Ok(Some(BinOp::Eq)),
             lexer::Kind::Plus => Ok(Some(BinOp::Add)),
             lexer::Kind::Minus => Ok(Some(BinOp::Subtract)),
+            lexer::Kind::Mod => Ok(Some(BinOp::Mod)),
             lexer::Kind::Mask => Ok(Some(BinOp::Mask)),
             lexer::Kind::And => Ok(Some(BinOp::BitAnd)),
             lexer::Kind::Pipe => Ok(Some(BinOp::BitOr)),


### PR DESCRIPTION
Add support for `bit<8>` -> `bit<16>` conversions.  This is needed to allow the route selection algorithm to add an 8-bit `hash % route_count` result to a 16-bit table index.