### PR TITLE
a few type handling improvements

### DIFF
--- a/codegen/rust/src/lib.rs
+++ b/codegen/rust/src/lib.rs
@@ -213,7 +213,7 @@ fn rust_type(ty: &Type) -> TokenStream {
         Type::Bool => quote! { bool },
         Type::Error => todo!("generate error type"),
         Type::Bit(_size) => {
-            quote! { BitVec<u8, Msb0> }
+            quote! { BitVec::<u8, Msb0> }
         }
         Type::Int(_size) => todo!("generate int type"),
         Type::Varbit(_size) => todo!("generate varbit type"),

--- a/codegen/rust/src/pipeline.rs
+++ b/codegen/rust/src/pipeline.rs
@@ -840,7 +840,11 @@ impl<'a> PipelineGenerator<'a> {
                         control_param_types.push(quote! { &mut #ty });
                     }
                     _ => {
-                        control_param_types.push(quote! { &#ty });
+                        if p.ty == Type::Bool {
+                            control_param_types.push(quote! { #ty });
+                        } else {
+                            control_param_types.push(quote! { &#ty });
+                        }
                     }
                 }
             }
@@ -949,7 +953,11 @@ impl<'a> PipelineGenerator<'a> {
                     control_param_types.push(quote! { &mut #ty });
                 }
                 _ => {
-                    control_param_types.push(quote! { &#ty });
+                    if p.ty == Type::Bool {
+                        control_param_types.push(quote! { #ty });
+                    } else {
+                        control_param_types.push(quote! { &#ty });
+                    }
                 }
             }
         }


### PR DESCRIPTION
- pass booleans by value through action parameters
- use full form of BitVec::<u8,Msb0> in code generation to allow for default instantiation.