### PR TITLE
dont flip byte order on fields <= 8 bits

### DIFF
--- a/codegen/rust/src/header.rs
+++ b/codegen/rust/src/header.rs
@@ -69,32 +69,40 @@ impl<'a> HeaderGenerator<'a> {
                     let mut b = buf.view_bits::<Msb0>()[#offset..#end].to_owned();
                     // NOTE this barfing and then unbarfing a vec is to handle
                     // the p4 confused-endian data model.
-                    let mut v = b.into_vec();
-                    v.reverse();
-                    if ((#end-#offset) % 8) != 0 {
-                        if let Some(x) = v.iter_mut().last() {
-                            *x <<= (#offset % 8);
+                    if #end-#offset > 8 {
+                        let mut v = b.into_vec();
+                        v.reverse();
+                        if ((#end-#offset) % 8) != 0 {
+                            if let Some(x) = v.iter_mut().last() {
+                                *x <<= (#offset % 8);
+                            }
                         }
+                        let mut b = BitVec::<u8, Msb0>::from_vec(v);
+                        b.resize(#end-#offset, false);
+                        b
+                    } else {
+                        b
                     }
-                    let mut b = BitVec::<u8, Msb0>::from_vec(v);
-                    b.resize(#end-#offset, false);
-                    b
                 }
             });
             to_bitvec_statements.push(quote! {
                 // NOTE this barfing and then unbarfing a vec is to handle
                 // the p4 confused-endian data model.
-                let mut v = self.#name.clone().into_vec();
-                if ((#end-#offset) % 8) != 0 {
-                    if let Some(x) = v.iter_mut().last() {
-                        *x >>= ((#end - #offset) % 8);
+                if #end-#offset > 8 {
+                    let mut v = self.#name.clone().into_vec();
+                    if ((#end-#offset) % 8) != 0 {
+                        if let Some(x) = v.iter_mut().last() {
+                            *x >>= ((#end - #offset) % 8);
+                        }
                     }
+                    v.reverse();
+                    let n = (#end-#offset);
+                    let m = n%8;
+                    let mut b = BitVec::<u8, Msb0>::from_vec(v);
+                    x[#offset..#end] |= &b[m..];
+                } else {
+                    x[#offset..#end] |= self.#name.to_owned();
                 }
-                v.reverse();
-                let n = (#end-#offset);
-                let m = n%8;
-                let mut b = BitVec::<u8, Msb0>::from_vec(v);
-                x[#offset..#end] |= &b[m..];
 
             });
             checksum_statements.push(quote! {

--- a/codegen/rust/src/header.rs
+++ b/codegen/rust/src/header.rs
@@ -99,7 +99,11 @@ impl<'a> HeaderGenerator<'a> {
                     let n = (#end-#offset);
                     let m = n%8;
                     let mut b = BitVec::<u8, Msb0>::from_vec(v);
-                    x[#offset..#end] |= &b[m..];
+                    // this field may be null so check that we at least have
+                    // enough space to offset
+                    if b.len() > m {
+                        x[#offset..#end] |= &b[m..];
+                    }
                 } else {
                     x[#offset..#end] |= self.#name.to_owned();
                 }

--- a/test/src/ipv6.rs
+++ b/test/src/ipv6.rs
@@ -67,14 +67,4 @@ fn test_ipv6_parse() -> anyhow::Result<()> {
     assert_eq!(data.to_vec(), readback);
 
     Ok(())
-
-    /*
-    let version: BigUint = v6.version.unwrap().to_owned().into();
-    println!("version = {}", version);
-    assert_eq!(version, BigUint::from(6u8));
-
-    let traffic_class: BigUint = v6.traffic_class.unwrap().to_owned().into();
-    println!("traffic class = {}", traffic_class);
-    assert_eq!(traffic_class, BigUint::from(127u8));
-    */
 }

--- a/test/src/ipv6.rs
+++ b/test/src/ipv6.rs
@@ -1,0 +1,80 @@
+p4_macro::use_p4!("test/src/p4/sidecar-lite.p4");
+
+#[test]
+fn test_ipv6_parse() -> anyhow::Result<()> {
+    let mut data = [0u8; 40];
+    // version = 6
+    // traffic class = 127 (0x7f)
+    // flow label = 699050 (0xaaaaa)
+    data[0] = 0b0110_1111;
+    data[1] = 0b0111_1010;
+    //data[1] = 0b1010_1111;
+    data[2] = 0b1010_1010;
+    data[3] = 0b1010_1010;
+    // payload len 18247 (0x4747)
+    data[4] = 47;
+    data[5] = 47;
+    // next_hdr
+    data[6] = 99;
+    // hop_limit
+    data[7] = 10;
+    // src fd00::1
+    data[8] = 0xfd;
+    data[9] = 0x00;
+    data[10] = 0x00;
+    data[11] = 0x00;
+    data[12] = 0x00;
+    data[13] = 0x00;
+    data[14] = 0x00;
+    data[15] = 0x00;
+    data[16] = 0x00;
+    data[17] = 0x00;
+    data[18] = 0x00;
+    data[19] = 0x00;
+    data[20] = 0x00;
+    data[21] = 0x00;
+    data[22] = 0x00;
+    data[23] = 0x01;
+    // dst fd00::2
+    data[24] = 0xfd;
+    data[25] = 0x00;
+    data[26] = 0x00;
+    data[27] = 0x00;
+    data[28] = 0x00;
+    data[29] = 0x00;
+    data[30] = 0x00;
+    data[31] = 0x00;
+    data[32] = 0x00;
+    data[33] = 0x00;
+    data[34] = 0x00;
+    data[35] = 0x00;
+    data[36] = 0x00;
+    data[37] = 0x00;
+    data[38] = 0x00;
+    data[39] = 0x02;
+
+    let mut v6 = ipv6_h::new();
+    v6.set(&data).unwrap();
+
+    let ver: u8 = v6.version.to_owned().load_le();
+    assert_eq!(ver, 6);
+
+    let tc: u8 = v6.traffic_class.to_owned().load_le();
+    assert_eq!(tc, 127);
+
+    let bv = v6.to_bitvec();
+    let readback = bv.into_vec();
+    assert_eq!(data.to_vec(), readback);
+
+    Ok(())
+
+    /*
+    let version: BigUint = v6.version.unwrap().to_owned().into();
+    println!("version = {}", version);
+    assert_eq!(version, BigUint::from(6u8));
+
+    let traffic_class: BigUint = v6.traffic_class.unwrap().to_owned().into();
+    println!("traffic class = {}", traffic_class);
+    assert_eq!(traffic_class, BigUint::from(127u8));
+    */
+}

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 #[cfg(test)]
 mod basic_router;
 #[cfg(test)]
@@ -14,6 +16,8 @@ mod dynamic_router;
 mod headers;
 #[cfg(test)]
 mod hub;
+#[cfg(test)]
+mod ipv6;
 #[cfg(test)]
 mod mac_rewrite;
 #[cfg(test)]


### PR DESCRIPTION
- due to bitvector capacity accounting these fields can expand into 2 bytes as vectors, and if we reorder them, the values get corrupted.
- check for null fields on deserialization
- fixes #50 