### PR TITLE
fix vlan example code in book

### DIFF
--- a/book/code/src/bin/vlan-switch.rs
+++ b/book/code/src/bin/vlan-switch.rs
@@ -20,14 +20,14 @@ fn main() -> Result<(), anyhow::Error> {
 
 fn init_tables(pipeline: &mut main_pipeline, m1: [u8; 6], m2: [u8; 6]) {
     // add static forwarding entries
-    pipeline.add_ingress_fwd_fib_entry("forward", &m1, &0u16.to_be_bytes(), 0);
-    pipeline.add_ingress_fwd_fib_entry("forward", &m2, &1u16.to_be_bytes(), 0);
+    pipeline.add_ingress_fwd_fib_entry("forward", &m1, &0u16.to_le_bytes(), 0);
+    pipeline.add_ingress_fwd_fib_entry("forward", &m2, &1u16.to_le_bytes(), 0);
 
     // port 0 vlan 47
     pipeline.add_ingress_vlan_port_vlan_entry(
         "filter",
-        0u16.to_be_bytes().as_ref(),
-        47u16.to_be_bytes().as_ref(),
+        0u16.to_le_bytes().as_ref(),
+        47u16.to_le_bytes().as_ref(),
         0,
     );
 
@@ -38,8 +38,8 @@ fn init_tables(pipeline: &mut main_pipeline, m1: [u8; 6], m2: [u8; 6]) {
     // port 1 vlan 47
     pipeline.add_ingress_vlan_port_vlan_entry(
         "filter",
-        1u16.to_be_bytes().as_ref(),
-        47u16.to_be_bytes().as_ref(),
+        1u16.to_le_bytes().as_ref(),
+        47u16.to_le_bytes().as_ref(),
         0,
     );
 }
@@ -56,14 +56,14 @@ fn run_test(
     npu.run();
 
     // send a packet we expect to make it through
-    phy1.send(&[TxFrame::newv(m2, 0, b"blueberry", 47)])?;
+    phy1.send(&[TxFrame::newv(m2, 0x8100, b"blueberry", 47)])?;
     expect_frames!(phy2, &[RxFrame::newv(phy1.mac, 0x8100, b"blueberry", 47)]);
 
     // send 3 packets, we expect the first 2 to get filtered by vlan rules
-    phy1.send(&[TxFrame::newv(m2, 0, b"poppyseed", 74)])?; // 74 != 47
+    phy1.send(&[TxFrame::newv(m2, 0x8100, b"poppyseed", 74)])?; // 74 != 47
     phy1.send(&[TxFrame::new(m2, 0, b"banana")])?; // no tag
-    phy1.send(&[TxFrame::newv(m2, 0, b"muffin", 47)])?;
-    phy1.send(&[TxFrame::newv(m3, 0, b"nut", 47)])?; // no forwarding entry
+    phy1.send(&[TxFrame::newv(m2, 0x8100, b"muffin", 47)])?;
+    phy1.send(&[TxFrame::newv(m3, 0x8100, b"nut", 47)])?; // no forwarding entry
     expect_frames!(phy2, &[RxFrame::newv(phy1.mac, 0x8100, b"muffin", 47)]);
 
     Ok(())


### PR DESCRIPTION
Addresses
- #58

The book VLAN example code has bit-rotted. In particular, it was behind on how the endianness of parameters needs to be passed into pipeline functions.

I'll work on updating this PR to put book examples in CI so this does not happen in the future.