### PR TITLE
Fix invalid trailing comma

### DIFF
--- a/book/text/src/01-02-hello_world.md
+++ b/book/text/src/01-02-hello_world.md
@@ -367,7 +367,7 @@ control egress(
 SoftNPU(
     parse(),
     ingress(),
-    egress(),
+    egress()
 ) main;
 ```
 


### PR DESCRIPTION
I had issues compiling the example code due to a trailing comma.  The comma isn't present in `book/code/src/bin/hello-world.p4`, so I assume it's not supposed to be here.

The example is also missing a definition of `packet_in`, e.g.
```p4
extern packet_in {
    void extract<T>(out T headerLvalue);
    void extract<T>(out T variableSizeHeader, in bit<32> varFieldSizeBits);
    T lookahead<T>();
    bit<32> length();  // This method may be unavailable in some architectures
    void advance(bit<32> bits);
}
```
I'm not sure if you want to add that, or whether it would be too confusing