### PR TITLE
Support trailing commas in package instance

### DIFF
--- a/p4/src/parser.rs
+++ b/p4/src/parser.rs
@@ -929,7 +929,14 @@ impl<'a, 'b> GlobalParser<'a, 'b> {
 
         self.parser.expect_token(lexer::Kind::ParenOpen)?;
         loop {
-            let (arg, _) = self.parser.parse_identifier("package name")?;
+            let token = self.parser.next_token()?;
+            let (arg, _) = match token.kind {
+                lexer::Kind::ParenClose => break,
+                _ => {
+                    self.parser.backlog.push(token);
+                    self.parser.parse_identifier("package_name")?
+                }
+            };
             self.parser.expect_token(lexer::Kind::ParenOpen)?;
             self.parser.expect_token(lexer::Kind::ParenClose)?;
             inst.parameters.push(arg);

--- a/test/src/p4/router.p4
+++ b/test/src/p4/router.p4
@@ -5,7 +5,7 @@
 SoftNPU(
     parse(),
     ingress(),
-    egress()
+    egress(),
 ) main;
 
 struct headers_t {


### PR DESCRIPTION
I picked a random P4 test file and added a trailing comma, then fixed the parser to support it.