### PR TITLE
Fix: Use #[unsafe(no_mangle)] for Rust 2024 compatibility

### DIFF
--- a/codegen/rust/src/pipeline.rs
+++ b/codegen/rust/src/pipeline.rs
@@ -161,7 +161,7 @@ impl<'a> PipelineGenerator<'a> {
 
             unsafe impl Send for #pipeline_name { }
 
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub extern "C" fn #c_create_fn(radix: u16)
             -> *mut dyn p4rs::Pipeline{
                 let pipeline = main_pipeline::new(radix);


### PR DESCRIPTION
The Rust 2024 edition requires the use of `#[unsafe(no_mangle)]` instead of `#[no_mangle]`. This commit updates the code generation to use the new attribute, ensuring compatibility with the latest Rust edition.

This works [starting from Rust 1.8.2](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html), but breaks compatibility with Rust < 1.8.2. Rust 1.8.2 was released on 17 October, 2024. 

Fixes https://github.com/oxidecomputer/p4/issues/194.