### PR TITLE
pass control scope externs to apply block action calls

### DIFF
--- a/codegen/rust/src/statement.rs
+++ b/codegen/rust/src/statement.rs
@@ -347,6 +347,16 @@ impl<'a> StatementGenerator<'a> {
             args.push(quote! { #arg });
         }
 
+        // pass externs instantiated at control scope to actions
+        for x in &control.variables {
+            if let Type::UserDefined(typename) = &x.ty {
+                if self.ast.get_extern(typename).is_some() {
+                    let arg = format_ident!("{}", x.name);
+                    args.push(quote! { & #arg });
+                }
+            }
+        }
+
         tokens.extend(quote! {
             #(#lvref).*(#(#args),*);
         })


### PR DESCRIPTION
Externs being instantiated at control scope were not being passed to actions when called from an apply block. This PR fixes that.